### PR TITLE
Handle test error/failures missing file info

### DIFF
--- a/src/junit_xml.jl
+++ b/src/junit_xml.jl
@@ -57,11 +57,11 @@ function JUnitTestCase(ti, run_number::Int)
 end
 
 function _error_message(fail::Test.Fail, ti)
-    file = relpath(String(fail.source.file), ti.project_root)
+    file = isnothing(fail.source.file) ? "unknown" : relpath(String(fail.source.file), ti.project_root)
     return string("Test failed at ", file, ":", fail.source.line)
 end
 function _error_message(err::Test.Error, ti)
-    file = relpath(String(err.source.file), ti.project_root)
+    file = isnothing(err.source.file) ? "unknown" : relpath(String(err.source.file), ti.project_root)
     return string("Error during test at ", file, ":", err.source.line)
 end
 function _error_message(ts::Test.DefaultTestSet, ti)

--- a/test/internals.jl
+++ b/test/internals.jl
@@ -154,3 +154,14 @@ end
     push!(ts.results, Error(:test_nonbool, "\"False\"", nothing, nothing, LineNumberNode(43)));
     @test_nowarn report_empty_testsets(ti, ts)
 end
+
+@testset "JUnit _error_message" begin
+    # Test we cope with the Error/Fail not having file info
+    using ReTestItems: _error_message
+    line_info = LineNumberNode(42, nothing)
+    ti = (; project_root=pkgdir(ReTestItems))  # Don't need a full testitem here
+    err = Test.Error(:nontest_error, Expr(:tuple), ErrorException(""), Base.ExceptionStack([]), line_info)
+    @test _error_message(err, ti) == "Error during test at unknown:42"
+    fail = Test.Fail(:test, Expr(:tuple), "data", "value", line_info)
+    @test _error_message(fail, ti) == "Test failed at unknown:42"
+end


### PR DESCRIPTION
Fix for:
```julia
  Got exception outside of a @test
  MethodError: no method matching String(::Nothing)
  Closest candidates are:
    String(!Matched::StringEncodings.Encodings.Encoding{enc}) where enc at ~/.julia/packages/StringEncodings/hHXRr/src/encodings.jl:18
    String(!Matched::WeakRefStrings.WeakRefString) at ~/.julia/packages/WeakRefStrings/31nkb/src/WeakRefStrings.jl:82
    String(!Matched::T) where T<:InlineStrings.InlineString at ~/.julia/packages/InlineStrings/HDs9F/src/InlineStrings.jl:131
    ...
  Stacktrace:
    [1] _error_message(err::Test.Error, ti::TestItem)
      @ ReTestItems ~/packages/ReTestItems/src/junit_xml.jl:64
    [2] _error_message(ts::Test.DefaultTestSet, ti::TestItem)
      @ ReTestItems ~/packages/ReTestItems/src/junit_xml.jl:70
    [3] JUnitTestCase(ti::TestItem, run_number::Int64)
      @ ReTestItems ~/packages/ReTestItems/src/junit_xml.jl:54
    [4] #4
      @ ./generator.jl:0 [inlined]
    [5] iterate
      @ ./generator.jl:47 [inlined]
    [6] collect(itr::Base.Generator{UnitRange{Int64}, ReTestItems.var"#4#5"{TestItem}})
      @ Base ./array.jl:787
    [7] testcases
      @ ~/packages/ReTestItems/src/junit_xml.jl:40 [inlined]
    [8] junit_record!
      @ ~/packages/ReTestItems/src/junit_xml.jl:112 [inlined]
    [9] record_results!(file::ReTestItems.FileNode, ti::TestItem)
      @ ReTestItems ~/packages/ReTestItems/src/testcontext.jl:142
   [10] #20
      @ ~/packages/ReTestItems/src/testcontext.jl:132 [inlined]
   [11] foreach
      @ ./abstractarray.jl:2774 [inlined]
```