### PR TITLE
Re-enable log capture tests for testsetups

### DIFF
--- a/src/workers.jl
+++ b/src/workers.jl
@@ -89,7 +89,9 @@ function terminate!(w::Worker, from::Symbol=:manual)
         sleep(0.1)
         process_exited(w.process) && break
     end
-    close(w.socket)
+    if !(w.socket.status == Base.StatusUninit || w.socket.status == Base.StatusInit || w.socket.handle === C_NULL)
+        close(w.socket)
+    end
     return
 end
 


### PR DESCRIPTION
This also includes a minor fix for workers where, only during testing, we were making and then terminating workers so quickly that their socket wasn't getting initialized properly and we were getting a harmless error.