### PR TITLE
Allow a longer timeout on the timeout tests to reduce false failures

### DIFF
--- a/test/integrationtests.jl
+++ b/test/integrationtests.jl
@@ -607,7 +607,7 @@ end
     # is replaced after the timeout and subsequent testitems still run.
     nworkers = 1
     @assert nworkers == 1
-    results = encased_testset(()->runtests(file; nworkers, debug=1, testitem_timeout=2.0))
+    results = encased_testset(()->runtests(file; nworkers, debug=1, testitem_timeout=4.0))
     @test n_tests(results) == 2
     @test n_passed(results) == 1
     # Test the error is as expected


### PR DESCRIPTION
- Now that the timeout tests run some testitems that are _not_ expected to timeout, we should be a little more forgiving in how long we wait, so that these don't accidentally get timed out and cause spurious pipeline failures (like https://github.com/JuliaTesting/ReTestItems.jl/actions/runs/4628524065/jobs/8188333595)