### PR TITLE
Make `Workers` respect `color` of target `IO`

### DIFF
--- a/src/workers.jl
+++ b/src/workers.jl
@@ -155,7 +155,8 @@ function Worker(;
     env["RETESTITEMS_INTERACTIVE"] = get(env, "RETESTITEMS_INTERACTIVE", string(Base.isinteractive()))
     # end copied from Distributed.launch
     ## start the worker process
-    cmd = `$(Base.julia_cmd()) $exeflags --startup-file=no -e 'using ReTestItems; ReTestItems.Workers.startworker()'`
+    color = get(worker_redirect_io, :color, false) ? "yes" : "no" # respect color of target io
+    cmd = `$(Base.julia_cmd()) $exeflags --startup-file=no --color=$color -e 'using ReTestItems; ReTestItems.Workers.startworker()'`
     proc = open(detach(setenv(addenv(cmd, env), dir=dir)), "r+")
     pid = Libc.getpid(proc)
 

--- a/src/workers.jl
+++ b/src/workers.jl
@@ -179,7 +179,7 @@ function Worker(;
         ## start a task to listen for worker messages
         w.messages = Threads.@spawn process_responses(w)
         # add a finalizer
-        finalizer(x -> terminate!(x, :finalizer), w)
+        finalizer(x -> @async(terminate!(x, :finalizer)), w) # @async to allow a task switch
         if isassigned(GLOBAL_CALLBACK_PER_WORKER)
             GLOBAL_CALLBACK_PER_WORKER[](w)
         end

--- a/test/log_capture.jl
+++ b/test/log_capture.jl
@@ -12,6 +12,19 @@ using ReTestItems, Test
     end
 end
 
+@testset "Workers print in color" begin
+    project_path = pkgdir(ReTestItems)
+    code = """
+    using ReTestItems.Workers
+    remote_fetch(Worker(), :(printstyled("this better ber red\n", color=:red)))
+    """
+    # Need to run in a separate process to force --color=yes in CI.
+    logs = IOCapture.capture(color=true) do
+        run(`$(Base.julia_cmd()) --project=$project_path --color=yes -e $code`)
+    end
+    @test endswith(logs.output,  "\e[31mthis better ber red\e[39m\n")
+end
+
 @testset "log capture -- reporting" begin
     setup1 = @testsetup module TheTestSetup1 end
     setup2 = @testsetup module TheTestSetup2 end


### PR DESCRIPTION
By default, the spawned Julia worker process would not print in color because its `stdout` does not support it. But we only care about the IO we redirect the outputs to.