### PR TITLE
Wrap `_runtests_in_current_env` in current logger to avoid world age issues

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReTestItems"
 uuid = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
-version = "1.3.0"
+version = "1.3.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"


### PR DESCRIPTION
fixes the first issue in https://relationalai.atlassian.net/browse/RAI-12275  -- tested to work locally

(related to #32 but doesn't actually add a test because it is surprisingly difficult to test, and also this issue is fixed upstream on master https://github.com/JuliaLang/julia/issues/33865#issuecomment-1527900246)