### PR TITLE
Record in JUnit run time ignoring compile time and GC

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReTestItems"
 uuid = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
-version = "1.3.1"
+version = "1.4.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/junit_xml.jl
+++ b/src/junit_xml.jl
@@ -218,14 +218,14 @@ function write_dd_tags(io, x::PerfStats)
     gctime = x.gctime / 1e9
     compile_time = x.compile_time / 1e9
     recompile_time = x.recompile_time / 1e9
-    run_time = (x.elapsedtime / 1e9) - gctime - compile_time  # compile_time includes recompile_time
+    eval_time = (x.elapsedtime / 1e9) - gctime - compile_time  # compile_time includes recompile_time
     write(io, "\n\t\t<properties>")
     write(io, "\n\t\t<property name=\"dd_tags[perf.bytes]\" value=\"$(x.bytes)\"></property>")
     write(io, "\n\t\t<property name=\"dd_tags[perf.allocs]\" value=\"$(x.allocs)\"></property>")
     write(io, "\n\t\t<property name=\"dd_tags[perf.gctime]\" value=\"$(gctime)\"></property>")
     write(io, "\n\t\t<property name=\"dd_tags[perf.compile_time]\" value=\"$(compile_time)\"></property>")
     write(io, "\n\t\t<property name=\"dd_tags[perf.recompile_time]\" value=\"$(recompile_time)\"></property>")
-    write(io, "\n\t\t<property name=\"dd_tags[perf.run_time]\" value=\"$(run_time)\"></property>")
+    write(io, "\n\t\t<property name=\"dd_tags[perf.eval_time]\" value=\"$(eval_time)\"></property>")
     write(io, "\n\t\t</properties>")
     return nothing
 end

--- a/src/junit_xml.jl
+++ b/src/junit_xml.jl
@@ -218,12 +218,14 @@ function write_dd_tags(io, x::PerfStats)
     gctime = x.gctime / 1e9
     compile_time = x.compile_time / 1e9
     recompile_time = x.recompile_time / 1e9
+    run_time = (x.elapsedtime / 1e9) - gctime - compile_time  # compile_time includes recompile_time
     write(io, "\n\t\t<properties>")
     write(io, "\n\t\t<property name=\"dd_tags[perf.bytes]\" value=\"$(x.bytes)\"></property>")
     write(io, "\n\t\t<property name=\"dd_tags[perf.allocs]\" value=\"$(x.allocs)\"></property>")
     write(io, "\n\t\t<property name=\"dd_tags[perf.gctime]\" value=\"$(gctime)\"></property>")
     write(io, "\n\t\t<property name=\"dd_tags[perf.compile_time]\" value=\"$(compile_time)\"></property>")
     write(io, "\n\t\t<property name=\"dd_tags[perf.recompile_time]\" value=\"$(recompile_time)\"></property>")
+    write(io, "\n\t\t<property name=\"dd_tags[perf.run_time]\" value=\"$(run_time)\"></property>")
     write(io, "\n\t\t</properties>")
     return nothing
 end

--- a/test/references/junit_xml_test_report.xml
+++ b/test/references/junit_xml_test_report.xml
@@ -1,60 +1,64 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites timestamp="2023-04-14T10:55:29.586" time="0.567" tests="13" skipped="3" failures="3" errors="2">
-<testsuite name="test/testfiles/_junit_xml_test.jl" timestamp="2023-04-14T10:55:29.586" time="0.567" tests="13" skipped="3" failures="3" errors="2">
-	<testcase name="testitem1" timestamp="2023-04-14T10:55:29.586" time="0.057" tests="2" skipped="0" failures="1" errors="0">
+<testsuites timestamp="2023-05-04T15:10:34.201" time="0.547" tests="13" skipped="3" failures="3" errors="2">
+<testsuite name="test/testfiles/_junit_xml_test.jl" timestamp="2023-05-04T15:10:34.201" time="0.547" tests="13" skipped="3" failures="3" errors="2">
+	<testcase name="testitem1" timestamp="2023-05-04T15:10:34.201" time="0.055" tests="2" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="4331408"></property>
 		<property name="dd_tags[perf.allocs]" value="74125"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.047217499"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.045606086"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.run_time]" value="0.005336247000000002"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_junit_xml_test.jl:4">No Captured Logs for test item "testitem1" at test/testfiles/_junit_xml_test.jl:2 on worker 95729
-Error in testset "testitem1" on worker 95729:
+		<error message="Test failed at test/testfiles/_junit_xml_test.jl:4">No Captured Logs for test item "testitem1" at test/testfiles/_junit_xml_test.jl:2 on worker 68484
+Error in testset "testitem1" on worker 68484:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:4
   Expression: 2 == 3
    Evaluated: 2 == 3
 		</error>
 	</testcase>
-	<testcase name="testitem2" timestamp="2023-04-14T10:55:29.781" time="0.032" tests="3" skipped="0" failures="1" errors="1">
+	<testcase name="testitem2" timestamp="2023-05-04T15:10:34.403" time="0.031" tests="3" skipped="0" failures="1" errors="1">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="3213927"></property>
 		<property name="dd_tags[perf.allocs]" value="57359"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.027965045"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.027250125"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.run_time]" value="0.004181707999999999"></property>
 		</properties>
-		<error message="Multiple errors for test item at test/testfiles/_junit_xml_test.jl:8">No Captured Logs for test item "testitem2" at test/testfiles/_junit_xml_test.jl:8 on worker 95729
-Error in testset "inner testset" on worker 95729:
+		<error message="Multiple errors for test item at test/testfiles/_junit_xml_test.jl:8">No Captured Logs for test item "testitem2" at test/testfiles/_junit_xml_test.jl:8 on worker 68484
+Error in testset "inner testset" on worker 68484:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:11
   Expression: 4 == 5
    Evaluated: 4 == 5
-Error in testset "inner testset" on worker 95729:
+Error in testset "inner testset" on worker 68484:
 Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:12
   Expression evaluated to non-Boolean
   Expression: not a bool
        Value: "not a bool"
 		</error>
 	</testcase>
-	<testcase name="testitem3" timestamp="2023-04-14T10:55:29.867" time="0.002" tests="2" skipped="0" failures="0" errors="0">
+	<testcase name="testitem3" timestamp="2023-05-04T15:10:34.488" time="0.002" tests="2" skipped="0" failures="0" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="70286"></property>
 		<property name="dd_tags[perf.allocs]" value="1176"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="4.1e-8"></property>
+		<property name="dd_tags[perf.compile_time]" value="1.67e-7"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.run_time]" value="0.002297166"></property>
 		</properties>
 	</testcase>
-	<testcase name="testitem4" timestamp="2023-04-14T10:55:29.918" time="0.463" tests="1" skipped="0" failures="0" errors="1">
+	<testcase name="testitem4" timestamp="2023-05-04T15:10:34.538" time="0.446" tests="1" skipped="0" failures="0" errors="1">
 		<properties>
-		<property name="dd_tags[perf.bytes]" value="78705018"></property>
-		<property name="dd_tags[perf.allocs]" value="1461922"></property>
-		<property name="dd_tags[perf.gctime]" value="0.004821625"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.381134665"></property>
+		<property name="dd_tags[perf.bytes]" value="78752010"></property>
+		<property name="dd_tags[perf.allocs]" value="1462662"></property>
+		<property name="dd_tags[perf.gctime]" value="0.004908167"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.373312916"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.run_time]" value="0.06759633399999998"></property>
 		</properties>
-		<error message="Error during test at test/testfiles/_junit_xml_test.jl:24">No Captured Logs for test item "testitem4" at test/testfiles/_junit_xml_test.jl:23 on worker 95729
-Error in testset "nested testset" on worker 95729:
+		<error message="Error during test at test/testfiles/_junit_xml_test.jl:24">No Captured Logs for test item "testitem4" at test/testfiles/_junit_xml_test.jl:23 on worker 68484
+Error in testset "nested testset" on worker 68484:
 Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:24
   Got exception outside of a @test
   UndefVarError: x not defined
@@ -67,19 +71,19 @@ Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml
       @ /repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:25
     [4] eval
       @ ./boot.jl:368 [inlined]
-    [5] #77
-      @ /repos/ReTestItems.jl/src/ReTestItems.jl:699 [inlined]
-    [6] with_source_path(f::ReTestItems.var"#77#80"{Expr}, path::String)
-      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:582
-    [7] #76
-      @ /repos/ReTestItems.jl/src/ReTestItems.jl:699 [inlined]
-    [8] redirect_stdio(f::ReTestItems.var"#76#79"{TestItem, Expr}; stdin::Nothing, stderr::IOContext{IOStream}, stdout::IOContext{IOStream})
+    [5] #81
+      @ /repos/ReTestItems.jl/src/ReTestItems.jl:701 [inlined]
+    [6] with_source_path(f::ReTestItems.var"#81#84"{Expr}, path::String)
+      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:584
+    [7] #80
+      @ /repos/ReTestItems.jl/src/ReTestItems.jl:701 [inlined]
+    [8] redirect_stdio(f::ReTestItems.var"#80#83"{TestItem, Expr}; stdin::Nothing, stderr::IOContext{IOStream}, stdout::IOContext{IOStream})
       @ Base ./stream.jl:1411
-    [9] _redirect_logs(f::ReTestItems.var"#76#79"{TestItem, Expr}, target::IOStream)
+    [9] _redirect_logs(f::ReTestItems.var"#80#83"{TestItem, Expr}, target::IOStream)
       @ ReTestItems /repos/ReTestItems.jl/src/log_capture.jl:111
-   [10] #25
+   [10] #27
       @ /repos/ReTestItems.jl/src/log_capture.jl:107 [inlined]
-   [11] open(::ReTestItems.var"#25#26"{ReTestItems.var"#76#79"{TestItem, Expr}}, ::String, ::Vararg{String}; kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
+   [11] open(::ReTestItems.var"#27#28"{ReTestItems.var"#80#83"{TestItem, Expr}}, ::String, ::Vararg{String}; kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
       @ Base ./io.jl:384
    [12] open
       @ ./io.jl:381 [inlined]
@@ -88,22 +92,22 @@ Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml
    [14] macro expansion
       @ /repos/ReTestItems.jl/src/macros.jl:81 [inlined]
    [15] runtestitem(ti::TestItem, ctx::ReTestItems.TestContext; verbose_results::Bool, finish_test::Bool, logs::Symbol)
-      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:698
+      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:700
    [16] _runtests_in_current_env(shouldrun::Function, paths::Tuple{String}, projectfile::String, nworkers::Int64, nworker_threads::Int64, worker_init_expr::Expr, testitem_timeout::Int64, retries::Int64, verbose_results::Bool, debug::Int64, report::Bool, logs::Symbol)
-      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:250
-   [17] #45
-      @ /repos/ReTestItems.jl/src/ReTestItems.jl:216 [inlined]
-   [18] (::TestEnv.var"#2#3"{ReTestItems.var"#45#47"{ReTestItems.var"#shouldrun_combined#42"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}})()
+      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:254
+   [17] #48
+      @ /repos/ReTestItems.jl/src/ReTestItems.jl:219 [inlined]
+   [18] (::TestEnv.var"#2#3"{ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}})()
       @ TestEnv /.julia/packages/TestEnv/bSUAo/src/activate_do.jl:19
-   [19] withenv(::TestEnv.var"#2#3"{ReTestItems.var"#45#47"{ReTestItems.var"#shouldrun_combined#42"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, ::Pair{String, String}, ::Vararg{Pair{String}})
+   [19] withenv(::TestEnv.var"#2#3"{ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, ::Pair{String, String}, ::Vararg{Pair{String}})
       @ Base ./env.jl:172
-   [20] (::Pkg.Operations.var"#107#112"{String, Bool, Bool, Bool, TestEnv.var"#2#3"{ReTestItems.var"#45#47"{ReTestItems.var"#shouldrun_combined#42"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, Pkg.Types.PackageSpec})()
+   [20] (::Pkg.Operations.var"#107#112"{String, Bool, Bool, Bool, TestEnv.var"#2#3"{ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, Pkg.Types.PackageSpec})()
       @ Pkg.Operations /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:1619
-   [21] with_temp_env(fn::Pkg.Operations.var"#107#112"{String, Bool, Bool, Bool, TestEnv.var"#2#3"{ReTestItems.var"#45#47"{ReTestItems.var"#shouldrun_combined#42"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, Pkg.Types.PackageSpec}, temp_env::String)
+   [21] with_temp_env(fn::Pkg.Operations.var"#107#112"{String, Bool, Bool, Bool, TestEnv.var"#2#3"{ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, Pkg.Types.PackageSpec}, temp_env::String)
       @ Pkg.Operations /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:1493
-   [22] (::Pkg.Operations.var"#105#110"{Nothing, Bool, Bool, Bool, TestEnv.var"#2#3"{ReTestItems.var"#45#47"{ReTestItems.var"#shouldrun_combined#42"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, Pkg.Types.Context, Pkg.Types.PackageSpec, String, Pkg.Types.Project, String})(tmp::String)
+   [22] (::Pkg.Operations.var"#105#110"{Nothing, Bool, Bool, Bool, TestEnv.var"#2#3"{ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, Pkg.Types.Context, Pkg.Types.PackageSpec, String, Pkg.Types.Project, String})(tmp::String)
       @ Pkg.Operations /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:1582
-   [23] mktempdir(fn::Pkg.Operations.var"#105#110"{Nothing, Bool, Bool, Bool, TestEnv.var"#2#3"{ReTestItems.var"#45#47"{ReTestItems.var"#shouldrun_combined#42"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, Pkg.Types.Context, Pkg.Types.PackageSpec, String, Pkg.Types.Project, String}, parent::String; prefix::String)
+   [23] mktempdir(fn::Pkg.Operations.var"#105#110"{Nothing, Bool, Bool, Bool, TestEnv.var"#2#3"{ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, Pkg.Types.Context, Pkg.Types.PackageSpec, String, Pkg.Types.Project, String}, parent::String; prefix::String)
       @ Base.Filesystem ./file.jl:764
    [24] mktempdir(fn::Function, parent::String) (repeats 2 times)
       @ Base.Filesystem ./file.jl:760
@@ -111,49 +115,57 @@ Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml
       @ Pkg.Operations /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:1540
    [26] sandbox
       @ /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:1531 [inlined]
-   [27] activate(f::ReTestItems.var"#45#47"{ReTestItems.var"#shouldrun_combined#42"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}, pkg::String)
+   [27] activate(f::ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}, pkg::String)
       @ TestEnv /.julia/packages/TestEnv/bSUAo/src/activate_do.jl:17
    [28] activate(f::Function)
       @ TestEnv /.julia/packages/TestEnv/bSUAo/src/activate_do.jl:13
-   [29] #44
-      @ /repos/ReTestItems.jl/src/ReTestItems.jl:215 [inlined]
-   [30] activate(f::ReTestItems.var"#44#46"{ReTestItems.var"#shouldrun_combined#42"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}, new_project::String)
+   [29] #47
+      @ /repos/ReTestItems.jl/src/ReTestItems.jl:218 [inlined]
+   [30] activate(f::ReTestItems.var"#47#50"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}, new_project::String)
       @ Pkg.API /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/API.jl:1707
-   [31] _runtests(shouldrun::Function, paths::Tuple{String}, nworkers::Int64, nworker_threads::Int64, worker_init_expr::Expr, testitem_timeout::Int64, retries::Int64, verbose_results::Bool, debug::Int64, report::Bool, logs::Symbol)
-      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:214
-   [32] runtests(shouldrun::typeof(ReTestItems.default_shouldrun), paths::String; nworkers::Int64, nworker_threads::Int64, worker_init_expr::Expr, testitem_timeout::Int64, retries::Int64, debug::Int64, name::Nothing, tags::Nothing, report::Bool, logs::Symbol, verbose_results::Bool)
+   [31] (::ReTestItems.var"#46#49"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String})()
+      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:217
+   [32] with_logstate(f::Function, logstate::Any)
+      @ Base.CoreLogging ./logging.jl:511
+   [33] with_logger
+      @ ./logging.jl:623 [inlined]
+   [34] _runtests(shouldrun::Function, paths::Tuple{String}, nworkers::Int64, nworker_threads::Int64, worker_init_expr::Expr, testitem_timeout::Int64, retries::Int64, verbose_results::Bool, debug::Int64, report::Bool, logs::Symbol)
+      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:210
+   [35] runtests(shouldrun::typeof(ReTestItems.default_shouldrun), paths::String; nworkers::Int64, nworker_threads::Int64, worker_init_expr::Expr, testitem_timeout::Int64, retries::Int64, debug::Int64, name::Nothing, tags::Nothing, report::Bool, logs::Symbol, verbose_results::Bool)
       @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:190
-   [33] #runtests#35
+   [36] #runtests#37
       @ /repos/ReTestItems.jl/src/ReTestItems.jl:140 [inlined]
-   [34] top-level scope
+   [37] top-level scope
       @ none:1
-   [35] eval
+   [38] eval
       @ ./boot.jl:368 [inlined]
-   [36] exec_options(opts::Base.JLOptions)
+   [39] exec_options(opts::Base.JLOptions)
       @ Base ./client.jl:276
-   [37] _start()
+   [40] _start()
       @ Base ./client.jl:522
 		</error>
 	</testcase>
-	<testcase name="testitem5" timestamp="2023-04-14T10:55:30.438" time="0.009" tests="3" skipped="2" failures="0" errors="0">
+	<testcase name="testitem5" timestamp="2023-05-04T15:10:35.038" time="0.009" tests="3" skipped="2" failures="0" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="83454"></property>
 		<property name="dd_tags[perf.allocs]" value="1433"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.006677753"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.006873415"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.run_time]" value="0.0025895430000000006"></property>
 		</properties>
 	</testcase>
-	<testcase name="testitem6" timestamp="2023-04-14T10:55:30.499" time="0.003" tests="2" skipped="1" failures="1" errors="0">
+	<testcase name="testitem6" timestamp="2023-05-04T15:10:35.097" time="0.003" tests="2" skipped="1" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="91886"></property>
 		<property name="dd_tags[perf.allocs]" value="1598"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="2.08e-7"></property>
+		<property name="dd_tags[perf.compile_time]" value="1.26e-7"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.run_time]" value="0.003191583"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_junit_xml_test.jl:41">No Captured Logs for test item "testitem6" at test/testfiles/_junit_xml_test.jl:40 on worker 95729
-Error in testset "testitem6" on worker 95729:
+		<error message="Test failed at test/testfiles/_junit_xml_test.jl:41">No Captured Logs for test item "testitem6" at test/testfiles/_junit_xml_test.jl:40 on worker 68484
+Error in testset "testitem6" on worker 68484:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:41
   Expression: false
 		</error>

--- a/test/references/junit_xml_test_report.xml
+++ b/test/references/junit_xml_test_report.xml
@@ -1,64 +1,64 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites timestamp="2023-05-04T15:10:34.201" time="0.547" tests="13" skipped="3" failures="3" errors="2">
-<testsuite name="test/testfiles/_junit_xml_test.jl" timestamp="2023-05-04T15:10:34.201" time="0.547" tests="13" skipped="3" failures="3" errors="2">
-	<testcase name="testitem1" timestamp="2023-05-04T15:10:34.201" time="0.055" tests="2" skipped="0" failures="1" errors="0">
+<testsuites timestamp="2023-05-09T17:27:12.837" time="0.58" tests="13" skipped="3" failures="3" errors="2">
+<testsuite name="test/testfiles/_junit_xml_test.jl" timestamp="2023-05-09T17:27:12.837" time="0.58" tests="13" skipped="3" failures="3" errors="2">
+	<testcase name="testitem1" timestamp="2023-05-09T17:27:12.837" time="0.065" tests="2" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="4331408"></property>
 		<property name="dd_tags[perf.allocs]" value="74125"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.045606086"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.055512587"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.run_time]" value="0.005336247000000002"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.0041838299999999995"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_junit_xml_test.jl:4">No Captured Logs for test item "testitem1" at test/testfiles/_junit_xml_test.jl:2 on worker 68484
-Error in testset "testitem1" on worker 68484:
+		<error message="Test failed at test/testfiles/_junit_xml_test.jl:4">No Captured Logs for test item "testitem1" at test/testfiles/_junit_xml_test.jl:2 on worker 61736
+Error in testset "testitem1" on worker 61736:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:4
   Expression: 2 == 3
    Evaluated: 2 == 3
 		</error>
 	</testcase>
-	<testcase name="testitem2" timestamp="2023-05-04T15:10:34.403" time="0.031" tests="3" skipped="0" failures="1" errors="1">
+	<testcase name="testitem2" timestamp="2023-05-09T17:27:13.063" time="0.032" tests="3" skipped="0" failures="1" errors="1">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="3213927"></property>
 		<property name="dd_tags[perf.allocs]" value="57359"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.027250125"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.027375085"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.run_time]" value="0.004181707999999999"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.004111123000000001"></property>
 		</properties>
-		<error message="Multiple errors for test item at test/testfiles/_junit_xml_test.jl:8">No Captured Logs for test item "testitem2" at test/testfiles/_junit_xml_test.jl:8 on worker 68484
-Error in testset "inner testset" on worker 68484:
+		<error message="Multiple errors for test item at test/testfiles/_junit_xml_test.jl:8">No Captured Logs for test item "testitem2" at test/testfiles/_junit_xml_test.jl:8 on worker 61736
+Error in testset "inner testset" on worker 61736:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:11
   Expression: 4 == 5
    Evaluated: 4 == 5
-Error in testset "inner testset" on worker 68484:
+Error in testset "inner testset" on worker 61736:
 Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:12
   Expression evaluated to non-Boolean
   Expression: not a bool
        Value: "not a bool"
 		</error>
 	</testcase>
-	<testcase name="testitem3" timestamp="2023-05-04T15:10:34.488" time="0.002" tests="2" skipped="0" failures="0" errors="0">
+	<testcase name="testitem3" timestamp="2023-05-09T17:27:13.15" time="0.002" tests="2" skipped="0" failures="0" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="70286"></property>
 		<property name="dd_tags[perf.allocs]" value="1176"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
 		<property name="dd_tags[perf.compile_time]" value="1.67e-7"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.run_time]" value="0.002297166"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.0022919999999999998"></property>
 		</properties>
 	</testcase>
-	<testcase name="testitem4" timestamp="2023-05-04T15:10:34.538" time="0.446" tests="1" skipped="0" failures="0" errors="1">
+	<testcase name="testitem4" timestamp="2023-05-09T17:27:13.201" time="0.469" tests="1" skipped="0" failures="0" errors="1">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="78752010"></property>
 		<property name="dd_tags[perf.allocs]" value="1462662"></property>
-		<property name="dd_tags[perf.gctime]" value="0.004908167"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.373312916"></property>
+		<property name="dd_tags[perf.gctime]" value="0.005105333"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.392469709"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.run_time]" value="0.06759633399999998"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.071699124"></property>
 		</properties>
-		<error message="Error during test at test/testfiles/_junit_xml_test.jl:24">No Captured Logs for test item "testitem4" at test/testfiles/_junit_xml_test.jl:23 on worker 68484
-Error in testset "nested testset" on worker 68484:
+		<error message="Error during test at test/testfiles/_junit_xml_test.jl:24">No Captured Logs for test item "testitem4" at test/testfiles/_junit_xml_test.jl:23 on worker 61736
+Error in testset "nested testset" on worker 61736:
 Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:24
   Got exception outside of a @test
   UndefVarError: x not defined
@@ -145,27 +145,27 @@ Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml
       @ Base ./client.jl:522
 		</error>
 	</testcase>
-	<testcase name="testitem5" timestamp="2023-05-04T15:10:35.038" time="0.009" tests="3" skipped="2" failures="0" errors="0">
+	<testcase name="testitem5" timestamp="2023-05-09T17:27:13.725" time="0.009" tests="3" skipped="2" failures="0" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="83454"></property>
 		<property name="dd_tags[perf.allocs]" value="1433"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.006873415"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.006706166"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.run_time]" value="0.0025895430000000006"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.002469501"></property>
 		</properties>
 	</testcase>
-	<testcase name="testitem6" timestamp="2023-05-04T15:10:35.097" time="0.003" tests="2" skipped="1" failures="1" errors="0">
+	<testcase name="testitem6" timestamp="2023-05-09T17:27:13.784" time="0.003" tests="2" skipped="1" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="91886"></property>
 		<property name="dd_tags[perf.allocs]" value="1598"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="1.26e-7"></property>
+		<property name="dd_tags[perf.compile_time]" value="1.66e-7"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.run_time]" value="0.003191583"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.003056542"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_junit_xml_test.jl:41">No Captured Logs for test item "testitem6" at test/testfiles/_junit_xml_test.jl:40 on worker 68484
-Error in testset "testitem6" on worker 68484:
+		<error message="Test failed at test/testfiles/_junit_xml_test.jl:41">No Captured Logs for test item "testitem6" at test/testfiles/_junit_xml_test.jl:40 on worker 61736
+Error in testset "testitem6" on worker 61736:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:41
   Expression: false
 		</error>

--- a/test/references/junit_xml_test_report_retries.xml
+++ b/test/references/junit_xml_test_report_retries.xml
@@ -1,95 +1,101 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites timestamp="2023-04-14T10:55:58.998" time="0.617" tests="21" skipped="4" failures="6" errors="4">
-<testsuite name="test/testfiles/_junit_xml_test.jl" timestamp="2023-04-14T10:55:58.998" time="0.617" tests="21" skipped="4" failures="6" errors="4">
-	<testcase name="testitem1" timestamp="2023-04-14T10:55:58.998" time="0.059" tests="2" skipped="0" failures="1" errors="0">
+<testsuites timestamp="2023-05-04T15:10:51.412" time="0.564" tests="21" skipped="4" failures="6" errors="4">
+<testsuite name="test/testfiles/_junit_xml_test.jl" timestamp="2023-05-04T15:10:51.412" time="0.564" tests="21" skipped="4" failures="6" errors="4">
+	<testcase name="testitem1" timestamp="2023-05-04T15:10:51.412" time="0.054" tests="2" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="4331408"></property>
 		<property name="dd_tags[perf.allocs]" value="74125"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.050207128"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.045528834"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.run_time]" value="0.0037055000000000005"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_junit_xml_test.jl:4">No Captured Logs for test item "testitem1" at test/testfiles/_junit_xml_test.jl:2 on worker 96175
-Error in testset "testitem1" on worker 96175:
+		<error message="Test failed at test/testfiles/_junit_xml_test.jl:4">No Captured Logs for test item "testitem1" at test/testfiles/_junit_xml_test.jl:2 on worker 68714
+Error in testset "testitem1" on worker 68714:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:4
   Expression: 2 == 3
    Evaluated: 2 == 3
 		</error>
 	</testcase>
-	<testcase name="testitem1" timestamp="2023-04-14T10:55:59.205" time="0.003" tests="2" skipped="0" failures="1" errors="0">
+	<testcase name="testitem1" timestamp="2023-05-04T15:10:51.614" time="0.002" tests="2" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="74086"></property>
 		<property name="dd_tags[perf.allocs]" value="1257"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="2.09e-7"></property>
+		<property name="dd_tags[perf.compile_time]" value="1.25e-7"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.run_time]" value="0.002374583"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_junit_xml_test.jl:4">No Captured Logs for test item "testitem1" at test/testfiles/_junit_xml_test.jl:2 on worker 96175
-Error in testset "testitem1" on worker 96175:
+		<error message="Test failed at test/testfiles/_junit_xml_test.jl:4">No Captured Logs for test item "testitem1" at test/testfiles/_junit_xml_test.jl:2 on worker 68714
+Error in testset "testitem1" on worker 68714:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:4
   Expression: 2 == 3
    Evaluated: 2 == 3
 		</error>
 	</testcase>
-	<testcase name="testitem2" timestamp="2023-04-14T10:55:59.263" time="0.04" tests="3" skipped="0" failures="1" errors="1">
+	<testcase name="testitem2" timestamp="2023-05-04T15:10:51.665" time="0.032" tests="3" skipped="0" failures="1" errors="1">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="3213927"></property>
 		<property name="dd_tags[perf.allocs]" value="57359"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.035184875"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.027547419"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.run_time]" value="0.004184873000000002"></property>
 		</properties>
-		<error message="Multiple errors for test item at test/testfiles/_junit_xml_test.jl:8">No Captured Logs for test item "testitem2" at test/testfiles/_junit_xml_test.jl:8 on worker 96175
-Error in testset "inner testset" on worker 96175:
+		<error message="Multiple errors for test item at test/testfiles/_junit_xml_test.jl:8">No Captured Logs for test item "testitem2" at test/testfiles/_junit_xml_test.jl:8 on worker 68714
+Error in testset "inner testset" on worker 68714:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:11
   Expression: 4 == 5
    Evaluated: 4 == 5
-Error in testset "inner testset" on worker 96175:
+Error in testset "inner testset" on worker 68714:
 Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:12
   Expression evaluated to non-Boolean
   Expression: not a bool
        Value: "not a bool"
 		</error>
 	</testcase>
-	<testcase name="testitem2" timestamp="2023-04-14T10:55:59.36" time="0.004" tests="3" skipped="0" failures="1" errors="1">
+	<testcase name="testitem2" timestamp="2023-05-04T15:10:51.749" time="0.004" tests="3" skipped="0" failures="1" errors="1">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="110342"></property>
 		<property name="dd_tags[perf.allocs]" value="1963"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="1.66e-7"></property>
+		<property name="dd_tags[perf.compile_time]" value="2.91e-7"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.run_time]" value="0.003806042"></property>
 		</properties>
-		<error message="Multiple errors for test item at test/testfiles/_junit_xml_test.jl:8">No Captured Logs for test item "testitem2" at test/testfiles/_junit_xml_test.jl:8 on worker 96175
-Error in testset "inner testset" on worker 96175:
+		<error message="Multiple errors for test item at test/testfiles/_junit_xml_test.jl:8">No Captured Logs for test item "testitem2" at test/testfiles/_junit_xml_test.jl:8 on worker 68714
+Error in testset "inner testset" on worker 68714:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:11
   Expression: 4 == 5
    Evaluated: 4 == 5
-Error in testset "inner testset" on worker 96175:
+Error in testset "inner testset" on worker 68714:
 Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:12
   Expression evaluated to non-Boolean
   Expression: not a bool
        Value: "not a bool"
 		</error>
 	</testcase>
-	<testcase name="testitem3" timestamp="2023-04-14T10:55:59.413" time="0.003" tests="2" skipped="0" failures="0" errors="0">
+	<testcase name="testitem3" timestamp="2023-05-04T15:10:51.801" time="0.002" tests="2" skipped="0" failures="0" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="70286"></property>
 		<property name="dd_tags[perf.allocs]" value="1176"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="8.2e-8"></property>
+		<property name="dd_tags[perf.compile_time]" value="8.3e-8"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.run_time]" value="0.002285208"></property>
 		</properties>
 	</testcase>
-	<testcase name="testitem4" timestamp="2023-04-14T10:55:59.468" time="0.487" tests="1" skipped="0" failures="0" errors="1">
+	<testcase name="testitem4" timestamp="2023-05-04T15:10:51.851" time="0.448" tests="1" skipped="0" failures="0" errors="1">
 		<properties>
-		<property name="dd_tags[perf.bytes]" value="78704922"></property>
-		<property name="dd_tags[perf.allocs]" value="1461919"></property>
-		<property name="dd_tags[perf.gctime]" value="0.005671542"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.411256708"></property>
+		<property name="dd_tags[perf.bytes]" value="78751914"></property>
+		<property name="dd_tags[perf.allocs]" value="1462659"></property>
+		<property name="dd_tags[perf.gctime]" value="0.00496075"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.373162793"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.run_time]" value="0.06983766600000002"></property>
 		</properties>
-		<error message="Error during test at test/testfiles/_junit_xml_test.jl:24">No Captured Logs for test item "testitem4" at test/testfiles/_junit_xml_test.jl:23 on worker 96175
-Error in testset "nested testset" on worker 96175:
+		<error message="Error during test at test/testfiles/_junit_xml_test.jl:24">No Captured Logs for test item "testitem4" at test/testfiles/_junit_xml_test.jl:23 on worker 68714
+Error in testset "nested testset" on worker 68714:
 Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:24
   Got exception outside of a @test
   UndefVarError: x not defined
@@ -102,19 +108,19 @@ Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml
       @ /repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:25
     [4] eval
       @ ./boot.jl:368 [inlined]
-    [5] #77
-      @ /repos/ReTestItems.jl/src/ReTestItems.jl:699 [inlined]
-    [6] with_source_path(f::ReTestItems.var"#77#80"{Expr}, path::String)
-      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:582
-    [7] #76
-      @ /repos/ReTestItems.jl/src/ReTestItems.jl:699 [inlined]
-    [8] redirect_stdio(f::ReTestItems.var"#76#79"{TestItem, Expr}; stdin::Nothing, stderr::IOContext{IOStream}, stdout::IOContext{IOStream})
+    [5] #81
+      @ /repos/ReTestItems.jl/src/ReTestItems.jl:701 [inlined]
+    [6] with_source_path(f::ReTestItems.var"#81#84"{Expr}, path::String)
+      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:584
+    [7] #80
+      @ /repos/ReTestItems.jl/src/ReTestItems.jl:701 [inlined]
+    [8] redirect_stdio(f::ReTestItems.var"#80#83"{TestItem, Expr}; stdin::Nothing, stderr::IOContext{IOStream}, stdout::IOContext{IOStream})
       @ Base ./stream.jl:1411
-    [9] _redirect_logs(f::ReTestItems.var"#76#79"{TestItem, Expr}, target::IOStream)
+    [9] _redirect_logs(f::ReTestItems.var"#80#83"{TestItem, Expr}, target::IOStream)
       @ ReTestItems /repos/ReTestItems.jl/src/log_capture.jl:111
-   [10] #25
+   [10] #27
       @ /repos/ReTestItems.jl/src/log_capture.jl:107 [inlined]
-   [11] open(::ReTestItems.var"#25#26"{ReTestItems.var"#76#79"{TestItem, Expr}}, ::String, ::Vararg{String}; kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
+   [11] open(::ReTestItems.var"#27#28"{ReTestItems.var"#80#83"{TestItem, Expr}}, ::String, ::Vararg{String}; kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
       @ Base ./io.jl:384
    [12] open
       @ ./io.jl:381 [inlined]
@@ -123,22 +129,22 @@ Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml
    [14] macro expansion
       @ /repos/ReTestItems.jl/src/macros.jl:81 [inlined]
    [15] runtestitem(ti::TestItem, ctx::ReTestItems.TestContext; verbose_results::Bool, finish_test::Bool, logs::Symbol)
-      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:698
+      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:700
    [16] _runtests_in_current_env(shouldrun::Function, paths::Tuple{String}, projectfile::String, nworkers::Int64, nworker_threads::Int64, worker_init_expr::Expr, testitem_timeout::Int64, retries::Int64, verbose_results::Bool, debug::Int64, report::Bool, logs::Symbol)
-      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:250
-   [17] #45
-      @ /repos/ReTestItems.jl/src/ReTestItems.jl:216 [inlined]
-   [18] (::TestEnv.var"#2#3"{ReTestItems.var"#45#47"{ReTestItems.var"#shouldrun_combined#42"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}})()
+      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:254
+   [17] #48
+      @ /repos/ReTestItems.jl/src/ReTestItems.jl:219 [inlined]
+   [18] (::TestEnv.var"#2#3"{ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}})()
       @ TestEnv /.julia/packages/TestEnv/bSUAo/src/activate_do.jl:19
-   [19] withenv(::TestEnv.var"#2#3"{ReTestItems.var"#45#47"{ReTestItems.var"#shouldrun_combined#42"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, ::Pair{String, String}, ::Vararg{Pair{String}})
+   [19] withenv(::TestEnv.var"#2#3"{ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, ::Pair{String, String}, ::Vararg{Pair{String}})
       @ Base ./env.jl:172
-   [20] (::Pkg.Operations.var"#107#112"{String, Bool, Bool, Bool, TestEnv.var"#2#3"{ReTestItems.var"#45#47"{ReTestItems.var"#shouldrun_combined#42"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, Pkg.Types.PackageSpec})()
+   [20] (::Pkg.Operations.var"#107#112"{String, Bool, Bool, Bool, TestEnv.var"#2#3"{ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, Pkg.Types.PackageSpec})()
       @ Pkg.Operations /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:1619
-   [21] with_temp_env(fn::Pkg.Operations.var"#107#112"{String, Bool, Bool, Bool, TestEnv.var"#2#3"{ReTestItems.var"#45#47"{ReTestItems.var"#shouldrun_combined#42"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, Pkg.Types.PackageSpec}, temp_env::String)
+   [21] with_temp_env(fn::Pkg.Operations.var"#107#112"{String, Bool, Bool, Bool, TestEnv.var"#2#3"{ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, Pkg.Types.PackageSpec}, temp_env::String)
       @ Pkg.Operations /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:1493
-   [22] (::Pkg.Operations.var"#105#110"{Nothing, Bool, Bool, Bool, TestEnv.var"#2#3"{ReTestItems.var"#45#47"{ReTestItems.var"#shouldrun_combined#42"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, Pkg.Types.Context, Pkg.Types.PackageSpec, String, Pkg.Types.Project, String})(tmp::String)
+   [22] (::Pkg.Operations.var"#105#110"{Nothing, Bool, Bool, Bool, TestEnv.var"#2#3"{ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, Pkg.Types.Context, Pkg.Types.PackageSpec, String, Pkg.Types.Project, String})(tmp::String)
       @ Pkg.Operations /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:1582
-   [23] mktempdir(fn::Pkg.Operations.var"#105#110"{Nothing, Bool, Bool, Bool, TestEnv.var"#2#3"{ReTestItems.var"#45#47"{ReTestItems.var"#shouldrun_combined#42"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, Pkg.Types.Context, Pkg.Types.PackageSpec, String, Pkg.Types.Project, String}, parent::String; prefix::String)
+   [23] mktempdir(fn::Pkg.Operations.var"#105#110"{Nothing, Bool, Bool, Bool, TestEnv.var"#2#3"{ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, Pkg.Types.Context, Pkg.Types.PackageSpec, String, Pkg.Types.Project, String}, parent::String; prefix::String)
       @ Base.Filesystem ./file.jl:764
    [24] mktempdir(fn::Function, parent::String) (repeats 2 times)
       @ Base.Filesystem ./file.jl:760
@@ -146,40 +152,47 @@ Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml
       @ Pkg.Operations /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:1540
    [26] sandbox
       @ /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:1531 [inlined]
-   [27] activate(f::ReTestItems.var"#45#47"{ReTestItems.var"#shouldrun_combined#42"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}, pkg::String)
+   [27] activate(f::ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}, pkg::String)
       @ TestEnv /.julia/packages/TestEnv/bSUAo/src/activate_do.jl:17
    [28] activate(f::Function)
       @ TestEnv /.julia/packages/TestEnv/bSUAo/src/activate_do.jl:13
-   [29] #44
-      @ /repos/ReTestItems.jl/src/ReTestItems.jl:215 [inlined]
-   [30] activate(f::ReTestItems.var"#44#46"{ReTestItems.var"#shouldrun_combined#42"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}, new_project::String)
+   [29] #47
+      @ /repos/ReTestItems.jl/src/ReTestItems.jl:218 [inlined]
+   [30] activate(f::ReTestItems.var"#47#50"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}, new_project::String)
       @ Pkg.API /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/API.jl:1707
-   [31] _runtests(shouldrun::Function, paths::Tuple{String}, nworkers::Int64, nworker_threads::Int64, worker_init_expr::Expr, testitem_timeout::Int64, retries::Int64, verbose_results::Bool, debug::Int64, report::Bool, logs::Symbol)
-      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:214
-   [32] runtests(shouldrun::typeof(ReTestItems.default_shouldrun), paths::String; nworkers::Int64, nworker_threads::Int64, worker_init_expr::Expr, testitem_timeout::Int64, retries::Int64, debug::Int64, name::Nothing, tags::Nothing, report::Bool, logs::Symbol, verbose_results::Bool)
+   [31] (::ReTestItems.var"#46#49"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String})()
+      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:217
+   [32] with_logstate(f::Function, logstate::Any)
+      @ Base.CoreLogging ./logging.jl:511
+   [33] with_logger
+      @ ./logging.jl:623 [inlined]
+   [34] _runtests(shouldrun::Function, paths::Tuple{String}, nworkers::Int64, nworker_threads::Int64, worker_init_expr::Expr, testitem_timeout::Int64, retries::Int64, verbose_results::Bool, debug::Int64, report::Bool, logs::Symbol)
+      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:210
+   [35] runtests(shouldrun::typeof(ReTestItems.default_shouldrun), paths::String; nworkers::Int64, nworker_threads::Int64, worker_init_expr::Expr, testitem_timeout::Int64, retries::Int64, debug::Int64, name::Nothing, tags::Nothing, report::Bool, logs::Symbol, verbose_results::Bool)
       @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:190
-   [33] #runtests#35
+   [36] #runtests#37
       @ /repos/ReTestItems.jl/src/ReTestItems.jl:140 [inlined]
-   [34] top-level scope
+   [37] top-level scope
       @ none:1
-   [35] eval
+   [38] eval
       @ ./boot.jl:368 [inlined]
-   [36] exec_options(opts::Base.JLOptions)
+   [39] exec_options(opts::Base.JLOptions)
       @ Base ./client.jl:276
-   [37] _start()
+   [40] _start()
       @ Base ./client.jl:522
 		</error>
 	</testcase>
-	<testcase name="testitem4" timestamp="2023-04-14T10:56:00.011" time="0.007" tests="1" skipped="0" failures="0" errors="1">
+	<testcase name="testitem4" timestamp="2023-05-04T15:10:52.353" time="0.007" tests="1" skipped="0" failures="0" errors="1">
 		<properties>
-		<property name="dd_tags[perf.bytes]" value="1101558"></property>
-		<property name="dd_tags[perf.allocs]" value="14339"></property>
+		<property name="dd_tags[perf.bytes]" value="1152662"></property>
+		<property name="dd_tags[perf.allocs]" value="15078"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="1.66e-7"></property>
+		<property name="dd_tags[perf.compile_time]" value="1.26e-7"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.run_time]" value="0.007018249000000001"></property>
 		</properties>
-		<error message="Error during test at test/testfiles/_junit_xml_test.jl:24">No Captured Logs for test item "testitem4" at test/testfiles/_junit_xml_test.jl:23 on worker 96175
-Error in testset "nested testset" on worker 96175:
+		<error message="Error during test at test/testfiles/_junit_xml_test.jl:24">No Captured Logs for test item "testitem4" at test/testfiles/_junit_xml_test.jl:23 on worker 68714
+Error in testset "nested testset" on worker 68714:
 Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:24
   Got exception outside of a @test
   UndefVarError: x not defined
@@ -192,19 +205,19 @@ Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml
       @ /repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:25
     [4] eval
       @ ./boot.jl:368 [inlined]
-    [5] #77
-      @ /repos/ReTestItems.jl/src/ReTestItems.jl:699 [inlined]
-    [6] with_source_path(f::ReTestItems.var"#77#80"{Expr}, path::String)
-      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:582
-    [7] #76
-      @ /repos/ReTestItems.jl/src/ReTestItems.jl:699 [inlined]
-    [8] redirect_stdio(f::ReTestItems.var"#76#79"{TestItem, Expr}; stdin::Nothing, stderr::IOContext{IOStream}, stdout::IOContext{IOStream})
+    [5] #81
+      @ /repos/ReTestItems.jl/src/ReTestItems.jl:701 [inlined]
+    [6] with_source_path(f::ReTestItems.var"#81#84"{Expr}, path::String)
+      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:584
+    [7] #80
+      @ /repos/ReTestItems.jl/src/ReTestItems.jl:701 [inlined]
+    [8] redirect_stdio(f::ReTestItems.var"#80#83"{TestItem, Expr}; stdin::Nothing, stderr::IOContext{IOStream}, stdout::IOContext{IOStream})
       @ Base ./stream.jl:1411
-    [9] _redirect_logs(f::ReTestItems.var"#76#79"{TestItem, Expr}, target::IOStream)
+    [9] _redirect_logs(f::ReTestItems.var"#80#83"{TestItem, Expr}, target::IOStream)
       @ ReTestItems /repos/ReTestItems.jl/src/log_capture.jl:111
-   [10] #25
+   [10] #27
       @ /repos/ReTestItems.jl/src/log_capture.jl:107 [inlined]
-   [11] open(::ReTestItems.var"#25#26"{ReTestItems.var"#76#79"{TestItem, Expr}}, ::String, ::Vararg{String}; kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
+   [11] open(::ReTestItems.var"#27#28"{ReTestItems.var"#80#83"{TestItem, Expr}}, ::String, ::Vararg{String}; kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
       @ Base ./io.jl:384
    [12] open
       @ ./io.jl:381 [inlined]
@@ -213,22 +226,22 @@ Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml
    [14] macro expansion
       @ /repos/ReTestItems.jl/src/macros.jl:81 [inlined]
    [15] runtestitem(ti::TestItem, ctx::ReTestItems.TestContext; verbose_results::Bool, finish_test::Bool, logs::Symbol)
-      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:698
+      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:700
    [16] _runtests_in_current_env(shouldrun::Function, paths::Tuple{String}, projectfile::String, nworkers::Int64, nworker_threads::Int64, worker_init_expr::Expr, testitem_timeout::Int64, retries::Int64, verbose_results::Bool, debug::Int64, report::Bool, logs::Symbol)
-      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:250
-   [17] #45
-      @ /repos/ReTestItems.jl/src/ReTestItems.jl:216 [inlined]
-   [18] (::TestEnv.var"#2#3"{ReTestItems.var"#45#47"{ReTestItems.var"#shouldrun_combined#42"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}})()
+      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:254
+   [17] #48
+      @ /repos/ReTestItems.jl/src/ReTestItems.jl:219 [inlined]
+   [18] (::TestEnv.var"#2#3"{ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}})()
       @ TestEnv /.julia/packages/TestEnv/bSUAo/src/activate_do.jl:19
-   [19] withenv(::TestEnv.var"#2#3"{ReTestItems.var"#45#47"{ReTestItems.var"#shouldrun_combined#42"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, ::Pair{String, String}, ::Vararg{Pair{String}})
+   [19] withenv(::TestEnv.var"#2#3"{ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, ::Pair{String, String}, ::Vararg{Pair{String}})
       @ Base ./env.jl:172
-   [20] (::Pkg.Operations.var"#107#112"{String, Bool, Bool, Bool, TestEnv.var"#2#3"{ReTestItems.var"#45#47"{ReTestItems.var"#shouldrun_combined#42"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, Pkg.Types.PackageSpec})()
+   [20] (::Pkg.Operations.var"#107#112"{String, Bool, Bool, Bool, TestEnv.var"#2#3"{ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, Pkg.Types.PackageSpec})()
       @ Pkg.Operations /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:1619
-   [21] with_temp_env(fn::Pkg.Operations.var"#107#112"{String, Bool, Bool, Bool, TestEnv.var"#2#3"{ReTestItems.var"#45#47"{ReTestItems.var"#shouldrun_combined#42"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, Pkg.Types.PackageSpec}, temp_env::String)
+   [21] with_temp_env(fn::Pkg.Operations.var"#107#112"{String, Bool, Bool, Bool, TestEnv.var"#2#3"{ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, Pkg.Types.PackageSpec}, temp_env::String)
       @ Pkg.Operations /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:1493
-   [22] (::Pkg.Operations.var"#105#110"{Nothing, Bool, Bool, Bool, TestEnv.var"#2#3"{ReTestItems.var"#45#47"{ReTestItems.var"#shouldrun_combined#42"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, Pkg.Types.Context, Pkg.Types.PackageSpec, String, Pkg.Types.Project, String})(tmp::String)
+   [22] (::Pkg.Operations.var"#105#110"{Nothing, Bool, Bool, Bool, TestEnv.var"#2#3"{ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, Pkg.Types.Context, Pkg.Types.PackageSpec, String, Pkg.Types.Project, String})(tmp::String)
       @ Pkg.Operations /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:1582
-   [23] mktempdir(fn::Pkg.Operations.var"#105#110"{Nothing, Bool, Bool, Bool, TestEnv.var"#2#3"{ReTestItems.var"#45#47"{ReTestItems.var"#shouldrun_combined#42"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, Pkg.Types.Context, Pkg.Types.PackageSpec, String, Pkg.Types.Project, String}, parent::String; prefix::String)
+   [23] mktempdir(fn::Pkg.Operations.var"#105#110"{Nothing, Bool, Bool, Bool, TestEnv.var"#2#3"{ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, Pkg.Types.Context, Pkg.Types.PackageSpec, String, Pkg.Types.Project, String}, parent::String; prefix::String)
       @ Base.Filesystem ./file.jl:764
    [24] mktempdir(fn::Function, parent::String) (repeats 2 times)
       @ Base.Filesystem ./file.jl:760
@@ -236,63 +249,72 @@ Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml
       @ Pkg.Operations /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:1540
    [26] sandbox
       @ /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:1531 [inlined]
-   [27] activate(f::ReTestItems.var"#45#47"{ReTestItems.var"#shouldrun_combined#42"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}, pkg::String)
+   [27] activate(f::ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}, pkg::String)
       @ TestEnv /.julia/packages/TestEnv/bSUAo/src/activate_do.jl:17
    [28] activate(f::Function)
       @ TestEnv /.julia/packages/TestEnv/bSUAo/src/activate_do.jl:13
-   [29] #44
-      @ /repos/ReTestItems.jl/src/ReTestItems.jl:215 [inlined]
-   [30] activate(f::ReTestItems.var"#44#46"{ReTestItems.var"#shouldrun_combined#42"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}, new_project::String)
+   [29] #47
+      @ /repos/ReTestItems.jl/src/ReTestItems.jl:218 [inlined]
+   [30] activate(f::ReTestItems.var"#47#50"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}, new_project::String)
       @ Pkg.API /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/API.jl:1707
-   [31] _runtests(shouldrun::Function, paths::Tuple{String}, nworkers::Int64, nworker_threads::Int64, worker_init_expr::Expr, testitem_timeout::Int64, retries::Int64, verbose_results::Bool, debug::Int64, report::Bool, logs::Symbol)
-      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:214
-   [32] runtests(shouldrun::typeof(ReTestItems.default_shouldrun), paths::String; nworkers::Int64, nworker_threads::Int64, worker_init_expr::Expr, testitem_timeout::Int64, retries::Int64, debug::Int64, name::Nothing, tags::Nothing, report::Bool, logs::Symbol, verbose_results::Bool)
+   [31] (::ReTestItems.var"#46#49"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String})()
+      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:217
+   [32] with_logstate(f::Function, logstate::Any)
+      @ Base.CoreLogging ./logging.jl:511
+   [33] with_logger
+      @ ./logging.jl:623 [inlined]
+   [34] _runtests(shouldrun::Function, paths::Tuple{String}, nworkers::Int64, nworker_threads::Int64, worker_init_expr::Expr, testitem_timeout::Int64, retries::Int64, verbose_results::Bool, debug::Int64, report::Bool, logs::Symbol)
+      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:210
+   [35] runtests(shouldrun::typeof(ReTestItems.default_shouldrun), paths::String; nworkers::Int64, nworker_threads::Int64, worker_init_expr::Expr, testitem_timeout::Int64, retries::Int64, debug::Int64, name::Nothing, tags::Nothing, report::Bool, logs::Symbol, verbose_results::Bool)
       @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:190
-   [33] #runtests#35
+   [36] #runtests#37
       @ /repos/ReTestItems.jl/src/ReTestItems.jl:140 [inlined]
-   [34] top-level scope
+   [37] top-level scope
       @ none:1
-   [35] eval
+   [38] eval
       @ ./boot.jl:368 [inlined]
-   [36] exec_options(opts::Base.JLOptions)
+   [39] exec_options(opts::Base.JLOptions)
       @ Base ./client.jl:276
-   [37] _start()
+   [40] _start()
       @ Base ./client.jl:522
 		</error>
 	</testcase>
-	<testcase name="testitem5" timestamp="2023-04-14T10:56:00.069" time="0.009" tests="3" skipped="2" failures="0" errors="0">
+	<testcase name="testitem5" timestamp="2023-05-04T15:10:52.409" time="0.009" tests="3" skipped="2" failures="0" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="83422"></property>
 		<property name="dd_tags[perf.allocs]" value="1432"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.007064708"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.007008999"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.run_time]" value="0.0023433759999999994"></property>
 		</properties>
 	</testcase>
-	<testcase name="testitem6" timestamp="2023-04-14T10:56:00.13" time="0.003" tests="2" skipped="1" failures="1" errors="0">
+	<testcase name="testitem6" timestamp="2023-05-04T15:10:52.468" time="0.003" tests="2" skipped="1" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="91886"></property>
 		<property name="dd_tags[perf.allocs]" value="1598"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="1.68e-7"></property>
+		<property name="dd_tags[perf.compile_time]" value="8.4e-8"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.run_time]" value="0.002974499"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_junit_xml_test.jl:41">No Captured Logs for test item "testitem6" at test/testfiles/_junit_xml_test.jl:40 on worker 96175
-Error in testset "testitem6" on worker 96175:
+		<error message="Test failed at test/testfiles/_junit_xml_test.jl:41">No Captured Logs for test item "testitem6" at test/testfiles/_junit_xml_test.jl:40 on worker 68714
+Error in testset "testitem6" on worker 68714:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:41
   Expression: false
 		</error>
 	</testcase>
-	<testcase name="testitem6" timestamp="2023-04-14T10:56:00.182" time="0.003" tests="2" skipped="1" failures="1" errors="0">
+	<testcase name="testitem6" timestamp="2023-05-04T15:10:52.519" time="0.003" tests="2" skipped="1" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="91886"></property>
 		<property name="dd_tags[perf.allocs]" value="1598"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="1.25e-7"></property>
+		<property name="dd_tags[perf.compile_time]" value="2.08e-7"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.run_time]" value="0.003104959"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_junit_xml_test.jl:41">No Captured Logs for test item "testitem6" at test/testfiles/_junit_xml_test.jl:40 on worker 96175
-Error in testset "testitem6" on worker 96175:
+		<error message="Test failed at test/testfiles/_junit_xml_test.jl:41">No Captured Logs for test item "testitem6" at test/testfiles/_junit_xml_test.jl:40 on worker 68714
+Error in testset "testitem6" on worker 68714:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:41
   Expression: false
 		</error>

--- a/test/references/junit_xml_test_report_retries.xml
+++ b/test/references/junit_xml_test_report_retries.xml
@@ -1,101 +1,101 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites timestamp="2023-05-04T15:10:51.412" time="0.564" tests="21" skipped="4" failures="6" errors="4">
-<testsuite name="test/testfiles/_junit_xml_test.jl" timestamp="2023-05-04T15:10:51.412" time="0.564" tests="21" skipped="4" failures="6" errors="4">
-	<testcase name="testitem1" timestamp="2023-05-04T15:10:51.412" time="0.054" tests="2" skipped="0" failures="1" errors="0">
+<testsuites timestamp="2023-05-09T17:29:05.904" time="0.564" tests="21" skipped="4" failures="6" errors="4">
+<testsuite name="test/testfiles/_junit_xml_test.jl" timestamp="2023-05-09T17:29:05.904" time="0.564" tests="21" skipped="4" failures="6" errors="4">
+	<testcase name="testitem1" timestamp="2023-05-09T17:29:05.904" time="0.053" tests="2" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="4331408"></property>
 		<property name="dd_tags[perf.allocs]" value="74125"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.045528834"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.045206915"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.run_time]" value="0.0037055000000000005"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.003664210000000001"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_junit_xml_test.jl:4">No Captured Logs for test item "testitem1" at test/testfiles/_junit_xml_test.jl:2 on worker 68714
-Error in testset "testitem1" on worker 68714:
+		<error message="Test failed at test/testfiles/_junit_xml_test.jl:4">No Captured Logs for test item "testitem1" at test/testfiles/_junit_xml_test.jl:2 on worker 63268
+Error in testset "testitem1" on worker 63268:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:4
   Expression: 2 == 3
    Evaluated: 2 == 3
 		</error>
 	</testcase>
-	<testcase name="testitem1" timestamp="2023-05-04T15:10:51.614" time="0.002" tests="2" skipped="0" failures="1" errors="0">
+	<testcase name="testitem1" timestamp="2023-05-09T17:29:06.105" time="0.002" tests="2" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="74086"></property>
 		<property name="dd_tags[perf.allocs]" value="1257"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="1.25e-7"></property>
+		<property name="dd_tags[perf.compile_time]" value="1.66e-7"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.run_time]" value="0.002374583"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.0023831670000000003"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_junit_xml_test.jl:4">No Captured Logs for test item "testitem1" at test/testfiles/_junit_xml_test.jl:2 on worker 68714
-Error in testset "testitem1" on worker 68714:
+		<error message="Test failed at test/testfiles/_junit_xml_test.jl:4">No Captured Logs for test item "testitem1" at test/testfiles/_junit_xml_test.jl:2 on worker 63268
+Error in testset "testitem1" on worker 63268:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:4
   Expression: 2 == 3
    Evaluated: 2 == 3
 		</error>
 	</testcase>
-	<testcase name="testitem2" timestamp="2023-05-04T15:10:51.665" time="0.032" tests="3" skipped="0" failures="1" errors="1">
+	<testcase name="testitem2" timestamp="2023-05-09T17:29:06.157" time="0.032" tests="3" skipped="0" failures="1" errors="1">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="3213927"></property>
 		<property name="dd_tags[perf.allocs]" value="57359"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.027547419"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.027600499"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.run_time]" value="0.004184873000000002"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.004031583999999998"></property>
 		</properties>
-		<error message="Multiple errors for test item at test/testfiles/_junit_xml_test.jl:8">No Captured Logs for test item "testitem2" at test/testfiles/_junit_xml_test.jl:8 on worker 68714
-Error in testset "inner testset" on worker 68714:
+		<error message="Multiple errors for test item at test/testfiles/_junit_xml_test.jl:8">No Captured Logs for test item "testitem2" at test/testfiles/_junit_xml_test.jl:8 on worker 63268
+Error in testset "inner testset" on worker 63268:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:11
   Expression: 4 == 5
    Evaluated: 4 == 5
-Error in testset "inner testset" on worker 68714:
+Error in testset "inner testset" on worker 63268:
 Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:12
   Expression evaluated to non-Boolean
   Expression: not a bool
        Value: "not a bool"
 		</error>
 	</testcase>
-	<testcase name="testitem2" timestamp="2023-05-04T15:10:51.749" time="0.004" tests="3" skipped="0" failures="1" errors="1">
+	<testcase name="testitem2" timestamp="2023-05-09T17:29:06.241" time="0.004" tests="3" skipped="0" failures="1" errors="1">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="110342"></property>
 		<property name="dd_tags[perf.allocs]" value="1963"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="2.91e-7"></property>
+		<property name="dd_tags[perf.compile_time]" value="1.25e-7"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.run_time]" value="0.003806042"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.003866208"></property>
 		</properties>
-		<error message="Multiple errors for test item at test/testfiles/_junit_xml_test.jl:8">No Captured Logs for test item "testitem2" at test/testfiles/_junit_xml_test.jl:8 on worker 68714
-Error in testset "inner testset" on worker 68714:
+		<error message="Multiple errors for test item at test/testfiles/_junit_xml_test.jl:8">No Captured Logs for test item "testitem2" at test/testfiles/_junit_xml_test.jl:8 on worker 63268
+Error in testset "inner testset" on worker 63268:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:11
   Expression: 4 == 5
    Evaluated: 4 == 5
-Error in testset "inner testset" on worker 68714:
+Error in testset "inner testset" on worker 63268:
 Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:12
   Expression evaluated to non-Boolean
   Expression: not a bool
        Value: "not a bool"
 		</error>
 	</testcase>
-	<testcase name="testitem3" timestamp="2023-05-04T15:10:51.801" time="0.002" tests="2" skipped="0" failures="0" errors="0">
+	<testcase name="testitem3" timestamp="2023-05-09T17:29:06.293" time="0.002" tests="2" skipped="0" failures="0" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="70286"></property>
 		<property name="dd_tags[perf.allocs]" value="1176"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="8.3e-8"></property>
+		<property name="dd_tags[perf.compile_time]" value="2.08e-7"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.run_time]" value="0.002285208"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.002306376"></property>
 		</properties>
 	</testcase>
-	<testcase name="testitem4" timestamp="2023-05-04T15:10:51.851" time="0.448" tests="1" skipped="0" failures="0" errors="1">
+	<testcase name="testitem4" timestamp="2023-05-09T17:29:06.343" time="0.448" tests="1" skipped="0" failures="0" errors="1">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="78751914"></property>
 		<property name="dd_tags[perf.allocs]" value="1462659"></property>
-		<property name="dd_tags[perf.gctime]" value="0.00496075"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.373162793"></property>
+		<property name="dd_tags[perf.gctime]" value="0.004786417"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.371259295"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.run_time]" value="0.06983766600000002"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.07191295400000003"></property>
 		</properties>
-		<error message="Error during test at test/testfiles/_junit_xml_test.jl:24">No Captured Logs for test item "testitem4" at test/testfiles/_junit_xml_test.jl:23 on worker 68714
-Error in testset "nested testset" on worker 68714:
+		<error message="Error during test at test/testfiles/_junit_xml_test.jl:24">No Captured Logs for test item "testitem4" at test/testfiles/_junit_xml_test.jl:23 on worker 63268
+Error in testset "nested testset" on worker 63268:
 Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:24
   Got exception outside of a @test
   UndefVarError: x not defined
@@ -182,17 +182,17 @@ Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml
       @ Base ./client.jl:522
 		</error>
 	</testcase>
-	<testcase name="testitem4" timestamp="2023-05-04T15:10:52.353" time="0.007" tests="1" skipped="0" failures="0" errors="1">
+	<testcase name="testitem4" timestamp="2023-05-09T17:29:06.846" time="0.007" tests="1" skipped="0" failures="0" errors="1">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="1152662"></property>
 		<property name="dd_tags[perf.allocs]" value="15078"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="1.26e-7"></property>
+		<property name="dd_tags[perf.compile_time]" value="8.4e-8"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.run_time]" value="0.007018249000000001"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.007121791"></property>
 		</properties>
-		<error message="Error during test at test/testfiles/_junit_xml_test.jl:24">No Captured Logs for test item "testitem4" at test/testfiles/_junit_xml_test.jl:23 on worker 68714
-Error in testset "nested testset" on worker 68714:
+		<error message="Error during test at test/testfiles/_junit_xml_test.jl:24">No Captured Logs for test item "testitem4" at test/testfiles/_junit_xml_test.jl:23 on worker 63268
+Error in testset "nested testset" on worker 63268:
 Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:24
   Got exception outside of a @test
   UndefVarError: x not defined
@@ -279,42 +279,42 @@ Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml
       @ Base ./client.jl:522
 		</error>
 	</testcase>
-	<testcase name="testitem5" timestamp="2023-05-04T15:10:52.409" time="0.009" tests="3" skipped="2" failures="0" errors="0">
+	<testcase name="testitem5" timestamp="2023-05-09T17:29:06.902" time="0.009" tests="3" skipped="2" failures="0" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="83422"></property>
 		<property name="dd_tags[perf.allocs]" value="1432"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.007008999"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.00689604"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.run_time]" value="0.0023433759999999994"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.002367877"></property>
 		</properties>
 	</testcase>
-	<testcase name="testitem6" timestamp="2023-05-04T15:10:52.468" time="0.003" tests="2" skipped="1" failures="1" errors="0">
+	<testcase name="testitem6" timestamp="2023-05-09T17:29:06.96" time="0.003" tests="2" skipped="1" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="91886"></property>
 		<property name="dd_tags[perf.allocs]" value="1598"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="8.4e-8"></property>
+		<property name="dd_tags[perf.compile_time]" value="1.67e-7"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.run_time]" value="0.002974499"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.0030277489999999997"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_junit_xml_test.jl:41">No Captured Logs for test item "testitem6" at test/testfiles/_junit_xml_test.jl:40 on worker 68714
-Error in testset "testitem6" on worker 68714:
+		<error message="Test failed at test/testfiles/_junit_xml_test.jl:41">No Captured Logs for test item "testitem6" at test/testfiles/_junit_xml_test.jl:40 on worker 63268
+Error in testset "testitem6" on worker 63268:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:41
   Expression: false
 		</error>
 	</testcase>
-	<testcase name="testitem6" timestamp="2023-05-04T15:10:52.519" time="0.003" tests="2" skipped="1" failures="1" errors="0">
+	<testcase name="testitem6" timestamp="2023-05-09T17:29:07.011" time="0.003" tests="2" skipped="1" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="91886"></property>
 		<property name="dd_tags[perf.allocs]" value="1598"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
 		<property name="dd_tags[perf.compile_time]" value="2.08e-7"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.run_time]" value="0.003104959"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.0030601260000000003"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_junit_xml_test.jl:41">No Captured Logs for test item "testitem6" at test/testfiles/_junit_xml_test.jl:40 on worker 68714
-Error in testset "testitem6" on worker 68714:
+		<error message="Test failed at test/testfiles/_junit_xml_test.jl:41">No Captured Logs for test item "testitem6" at test/testfiles/_junit_xml_test.jl:40 on worker 63268
+Error in testset "testitem6" on worker 63268:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:41
   Expression: false
 		</error>

--- a/test/references/retry_tests_report.xml
+++ b/test/references/retry_tests_report.xml
@@ -1,44 +1,47 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites timestamp="2023-04-14T10:56:25.176" time="0.557" tests="13" skipped="0" failures="10" errors="1">
-<testsuite name="test/testfiles/_retry_tests.jl" timestamp="2023-04-14T10:56:25.176" time="0.557" tests="13" skipped="0" failures="10" errors="1">
-	<testcase name="Pass on second run" timestamp="2023-04-14T10:56:25.176" time="0.094" tests="1" skipped="0" failures="1" errors="0">
+<testsuites timestamp="2023-05-04T15:11:07.405" time="0.57" tests="13" skipped="0" failures="10" errors="1">
+<testsuite name="test/testfiles/_retry_tests.jl" timestamp="2023-05-04T15:11:07.405" time="0.57" tests="13" skipped="0" failures="10" errors="1">
+	<testcase name="Pass on second run" timestamp="2023-05-04T15:11:07.405" time="0.094" tests="1" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="2479618"></property>
 		<property name="dd_tags[perf.allocs]" value="40557"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.033625794"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.033382959"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.run_time]" value="0.004477458000000004"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:15">Captured logs for test setup "StatefulSetup" (dependency of "Pass on second run") at test/testfiles/_retry_tests.jl:1 on worker 96822
+		<error message="Test failed at test/testfiles/_retry_tests.jl:15">Captured logs for test setup "StatefulSetup" (dependency of "Pass on second run") at test/testfiles/_retry_tests.jl:1 on worker 68950
 These are the test setup logs.
-No Captured Logs for test item "Pass on second run" at test/testfiles/_retry_tests.jl:10 on worker 96822
-Error in testset "Pass on second run" on worker 96822:
+No Captured Logs for test item "Pass on second run" at test/testfiles/_retry_tests.jl:10 on worker 68950
+Error in testset "Pass on second run" on worker 68950:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:15
   Expression: x
 		</error>
 	</testcase>
-	<testcase name="Pass on second run" timestamp="2023-04-14T10:56:25.413" time="0.002" tests="1" skipped="0" failures="0" errors="0">
+	<testcase name="Pass on second run" timestamp="2023-05-04T15:11:07.64" time="0.002" tests="1" skipped="0" failures="0" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="75878"></property>
 		<property name="dd_tags[perf.allocs]" value="1193"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="1.67e-7"></property>
+		<property name="dd_tags[perf.compile_time]" value="2.08e-7"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.run_time]" value="0.0024248330000000004"></property>
 		</properties>
 	</testcase>
-	<testcase name="Error, then Fail, then Pass" timestamp="2023-04-14T10:56:25.465" time="0.431" tests="1" skipped="0" failures="0" errors="1">
+	<testcase name="Error, then Fail, then Pass" timestamp="2023-05-04T15:11:07.692" time="0.442" tests="1" skipped="0" failures="0" errors="1">
 		<properties>
-		<property name="dd_tags[perf.bytes]" value="72685682"></property>
-		<property name="dd_tags[perf.allocs]" value="1352164"></property>
-		<property name="dd_tags[perf.gctime]" value="0.004815458"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.361215251"></property>
+		<property name="dd_tags[perf.bytes]" value="72685834"></property>
+		<property name="dd_tags[perf.allocs]" value="1352181"></property>
+		<property name="dd_tags[perf.gctime]" value="0.004862583"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.370313457"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.run_time]" value="0.06726416899999998"></property>
 		</properties>
-		<error message="Error during test at test/testfiles/_retry_tests.jl:24">Captured logs for test setup "StatefulSetup" (dependency of "Error, then Fail, then Pass") at test/testfiles/_retry_tests.jl:1 on worker 96822
+		<error message="Error during test at test/testfiles/_retry_tests.jl:24">Captured logs for test setup "StatefulSetup" (dependency of "Error, then Fail, then Pass") at test/testfiles/_retry_tests.jl:1 on worker 68950
 These are the test setup logs.
-Captured Logs for test item "Error, then Fail, then Pass" at test/testfiles/_retry_tests.jl:18 on worker 96822
+Captured Logs for test item "Error, then Fail, then Pass" at test/testfiles/_retry_tests.jl:18 on worker 68950
 These are the logs for run number: 1
-Error in testset "Error, then Fail, then Pass" on worker 96822:
+Error in testset "Error, then Fail, then Pass" on worker 68950:
 Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:24
   Test threw exception
   Expression: not_defined_err
@@ -50,157 +53,167 @@ Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tes
      @ /repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:24
 		</error>
 	</testcase>
-	<testcase name="Error, then Fail, then Pass" timestamp="2023-04-14T10:56:25.955" time="0.008" tests="1" skipped="0" failures="1" errors="0">
+	<testcase name="Error, then Fail, then Pass" timestamp="2023-05-04T15:11:08.198" time="0.008" tests="1" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="212803"></property>
 		<property name="dd_tags[perf.allocs]" value="3670"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.004493582"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.004825082"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.run_time]" value="0.003628626000000001"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:26">Captured logs for test setup "StatefulSetup" (dependency of "Error, then Fail, then Pass") at test/testfiles/_retry_tests.jl:1 on worker 96822
+		<error message="Test failed at test/testfiles/_retry_tests.jl:26">Captured logs for test setup "StatefulSetup" (dependency of "Error, then Fail, then Pass") at test/testfiles/_retry_tests.jl:1 on worker 68950
 These are the test setup logs.
-Captured Logs for test item "Error, then Fail, then Pass" at test/testfiles/_retry_tests.jl:18 on worker 96822
+Captured Logs for test item "Error, then Fail, then Pass" at test/testfiles/_retry_tests.jl:18 on worker 68950
 These are the logs for run number: 2
-Error in testset "Error, then Fail, then Pass" on worker 96822:
+Error in testset "Error, then Fail, then Pass" on worker 68950:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:26
   Expression: 2 + 2 == 5
    Evaluated: 4 == 5
 		</error>
 	</testcase>
-	<testcase name="Error, then Fail, then Pass" timestamp="2023-04-14T10:56:26.012" time="0.003" tests="1" skipped="0" failures="0" errors="0">
+	<testcase name="Error, then Fail, then Pass" timestamp="2023-05-04T15:11:08.257" time="0.003" tests="1" skipped="0" failures="0" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="100270"></property>
 		<property name="dd_tags[perf.allocs]" value="1675"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="8.3e-8"></property>
+		<property name="dd_tags[perf.compile_time]" value="8.4e-8"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.run_time]" value="0.003239582"></property>
 		</properties>
 	</testcase>
-	<testcase name="Has retries=4 and always fails" timestamp="2023-04-14T10:56:26.064" time="0.002" tests="1" skipped="0" failures="1" errors="0">
-		<properties>
-		<property name="dd_tags[perf.bytes]" value="73062"></property>
-		<property name="dd_tags[perf.allocs]" value="1137"></property>
-		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:35">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 96822
-These are the test setup logs.
-No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:32 on worker 96822
-Error in testset "Has retries=4 and always fails" on worker 96822:
-Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:35
-  Expression: false
-		</error>
-	</testcase>
-	<testcase name="Has retries=4 and always fails" timestamp="2023-04-14T10:56:26.114" time="0.002" tests="1" skipped="0" failures="1" errors="0">
+	<testcase name="Has retries=4 and always fails" timestamp="2023-05-04T15:11:08.308" time="0.003" tests="1" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="73062"></property>
 		<property name="dd_tags[perf.allocs]" value="1137"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
 		<property name="dd_tags[perf.compile_time]" value="8.3e-8"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.run_time]" value="0.003364917"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:35">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 96822
+		<error message="Test failed at test/testfiles/_retry_tests.jl:35">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 68950
 These are the test setup logs.
-No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:32 on worker 96822
-Error in testset "Has retries=4 and always fails" on worker 96822:
+No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:32 on worker 68950
+Error in testset "Has retries=4 and always fails" on worker 68950:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:35
   Expression: false
 		</error>
 	</testcase>
-	<testcase name="Has retries=4 and always fails" timestamp="2023-04-14T10:56:26.166" time="0.002" tests="1" skipped="0" failures="1" errors="0">
+	<testcase name="Has retries=4 and always fails" timestamp="2023-05-04T15:11:08.362" time="0.002" tests="1" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="73062"></property>
 		<property name="dd_tags[perf.allocs]" value="1137"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
 		<property name="dd_tags[perf.compile_time]" value="1.25e-7"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.run_time]" value="0.002144333"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:35">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 96822
+		<error message="Test failed at test/testfiles/_retry_tests.jl:35">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 68950
 These are the test setup logs.
-No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:32 on worker 96822
-Error in testset "Has retries=4 and always fails" on worker 96822:
+No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:32 on worker 68950
+Error in testset "Has retries=4 and always fails" on worker 68950:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:35
   Expression: false
 		</error>
 	</testcase>
-	<testcase name="Has retries=4 and always fails" timestamp="2023-04-14T10:56:26.218" time="0.002" tests="1" skipped="0" failures="1" errors="0">
+	<testcase name="Has retries=4 and always fails" timestamp="2023-05-04T15:11:08.411" time="0.002" tests="1" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="73062"></property>
 		<property name="dd_tags[perf.allocs]" value="1137"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="1.24e-7"></property>
+		<property name="dd_tags[perf.compile_time]" value="2.5e-7"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.run_time]" value="0.002227666"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:35">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 96822
+		<error message="Test failed at test/testfiles/_retry_tests.jl:35">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 68950
 These are the test setup logs.
-No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:32 on worker 96822
-Error in testset "Has retries=4 and always fails" on worker 96822:
+No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:32 on worker 68950
+Error in testset "Has retries=4 and always fails" on worker 68950:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:35
   Expression: false
 		</error>
 	</testcase>
-	<testcase name="Has retries=4 and always fails" timestamp="2023-04-14T10:56:26.27" time="0.002" tests="1" skipped="0" failures="1" errors="0">
+	<testcase name="Has retries=4 and always fails" timestamp="2023-05-04T15:11:08.461" time="0.002" tests="1" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="73062"></property>
 		<property name="dd_tags[perf.allocs]" value="1137"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="1.66e-7"></property>
+		<property name="dd_tags[perf.compile_time]" value="4.2e-8"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.run_time]" value="0.002120625"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:35">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 96822
+		<error message="Test failed at test/testfiles/_retry_tests.jl:35">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 68950
 These are the test setup logs.
-No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:32 on worker 96822
-Error in testset "Has retries=4 and always fails" on worker 96822:
+No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:32 on worker 68950
+Error in testset "Has retries=4 and always fails" on worker 68950:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:35
   Expression: false
 		</error>
 	</testcase>
-	<testcase name="Has retries=1 and always fails" timestamp="2023-04-14T10:56:26.321" time="0.002" tests="1" skipped="0" failures="1" errors="0">
+	<testcase name="Has retries=4 and always fails" timestamp="2023-05-04T15:11:08.511" time="0.002" tests="1" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="73062"></property>
 		<property name="dd_tags[perf.allocs]" value="1137"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.compile_time]" value="8.3e-8"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.run_time]" value="0.0021441249999999998"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:41">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=1 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 96822
+		<error message="Test failed at test/testfiles/_retry_tests.jl:35">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 68950
 These are the test setup logs.
-No Captured Logs for test item "Has retries=1 and always fails" at test/testfiles/_retry_tests.jl:38 on worker 96822
-Error in testset "Has retries=1 and always fails" on worker 96822:
+No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:32 on worker 68950
+Error in testset "Has retries=4 and always fails" on worker 68950:
+Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:35
+  Expression: false
+		</error>
+	</testcase>
+	<testcase name="Has retries=1 and always fails" timestamp="2023-05-04T15:11:08.559" time="0.003" tests="1" skipped="0" failures="1" errors="0">
+		<properties>
+		<property name="dd_tags[perf.bytes]" value="73062"></property>
+		<property name="dd_tags[perf.allocs]" value="1137"></property>
+		<property name="dd_tags[perf.gctime]" value="0.0"></property>
+		<property name="dd_tags[perf.compile_time]" value="4.2e-8"></property>
+		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.run_time]" value="0.002795083"></property>
+		</properties>
+		<error message="Test failed at test/testfiles/_retry_tests.jl:41">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=1 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 68950
+These are the test setup logs.
+No Captured Logs for test item "Has retries=1 and always fails" at test/testfiles/_retry_tests.jl:38 on worker 68950
+Error in testset "Has retries=1 and always fails" on worker 68950:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:41
   Expression: false
 		</error>
 	</testcase>
-	<testcase name="Has retries=1 and always fails" timestamp="2023-04-14T10:56:26.373" time="0.002" tests="1" skipped="0" failures="1" errors="0">
+	<testcase name="Has retries=1 and always fails" timestamp="2023-05-04T15:11:08.611" time="0.002" tests="1" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="73062"></property>
 		<property name="dd_tags[perf.allocs]" value="1137"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.compile_time]" value="4.2e-8"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.run_time]" value="0.002132792"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:41">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=1 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 96822
+		<error message="Test failed at test/testfiles/_retry_tests.jl:41">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=1 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 68950
 These are the test setup logs.
-No Captured Logs for test item "Has retries=1 and always fails" at test/testfiles/_retry_tests.jl:38 on worker 96822
-Error in testset "Has retries=1 and always fails" on worker 96822:
+No Captured Logs for test item "Has retries=1 and always fails" at test/testfiles/_retry_tests.jl:38 on worker 68950
+Error in testset "Has retries=1 and always fails" on worker 68950:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:41
   Expression: false
 		</error>
 	</testcase>
-	<testcase name="Has retries=1 and always fails" timestamp="2023-04-14T10:56:26.426" time="0.002" tests="1" skipped="0" failures="1" errors="0">
+	<testcase name="Has retries=1 and always fails" timestamp="2023-05-04T15:11:08.661" time="0.002" tests="1" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="73062"></property>
 		<property name="dd_tags[perf.allocs]" value="1137"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="5.0e-7"></property>
+		<property name="dd_tags[perf.compile_time]" value="3.75e-7"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.run_time]" value="0.002228875"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:41">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=1 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 96822
+		<error message="Test failed at test/testfiles/_retry_tests.jl:41">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=1 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 68950
 These are the test setup logs.
-No Captured Logs for test item "Has retries=1 and always fails" at test/testfiles/_retry_tests.jl:38 on worker 96822
-Error in testset "Has retries=1 and always fails" on worker 96822:
+No Captured Logs for test item "Has retries=1 and always fails" at test/testfiles/_retry_tests.jl:38 on worker 68950
+Error in testset "Has retries=1 and always fails" on worker 68950:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:41
   Expression: false
 		</error>

--- a/test/references/retry_tests_report.xml
+++ b/test/references/retry_tests_report.xml
@@ -1,47 +1,47 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites timestamp="2023-05-04T15:11:07.405" time="0.57" tests="13" skipped="0" failures="10" errors="1">
-<testsuite name="test/testfiles/_retry_tests.jl" timestamp="2023-05-04T15:11:07.405" time="0.57" tests="13" skipped="0" failures="10" errors="1">
-	<testcase name="Pass on second run" timestamp="2023-05-04T15:11:07.405" time="0.094" tests="1" skipped="0" failures="1" errors="0">
+<testsuites timestamp="2023-05-09T17:29:21.338" time="0.561" tests="13" skipped="0" failures="10" errors="1">
+<testsuite name="test/testfiles/_retry_tests.jl" timestamp="2023-05-09T17:29:21.338" time="0.561" tests="13" skipped="0" failures="10" errors="1">
+	<testcase name="Pass on second run" timestamp="2023-05-09T17:29:21.338" time="0.093" tests="1" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="2479618"></property>
 		<property name="dd_tags[perf.allocs]" value="40557"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.033382959"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.033515877"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.run_time]" value="0.004477458000000004"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.003170539"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:15">Captured logs for test setup "StatefulSetup" (dependency of "Pass on second run") at test/testfiles/_retry_tests.jl:1 on worker 68950
+		<error message="Test failed at test/testfiles/_retry_tests.jl:15">Captured logs for test setup "StatefulSetup" (dependency of "Pass on second run") at test/testfiles/_retry_tests.jl:1 on worker 63497
 These are the test setup logs.
-No Captured Logs for test item "Pass on second run" at test/testfiles/_retry_tests.jl:10 on worker 68950
-Error in testset "Pass on second run" on worker 68950:
+No Captured Logs for test item "Pass on second run" at test/testfiles/_retry_tests.jl:10 on worker 63497
+Error in testset "Pass on second run" on worker 63497:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:15
   Expression: x
 		</error>
 	</testcase>
-	<testcase name="Pass on second run" timestamp="2023-05-04T15:11:07.64" time="0.002" tests="1" skipped="0" failures="0" errors="0">
+	<testcase name="Pass on second run" timestamp="2023-05-09T17:29:21.575" time="0.002" tests="1" skipped="0" failures="0" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="75878"></property>
 		<property name="dd_tags[perf.allocs]" value="1193"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="2.08e-7"></property>
+		<property name="dd_tags[perf.compile_time]" value="1.25e-7"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.run_time]" value="0.0024248330000000004"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.002476959"></property>
 		</properties>
 	</testcase>
-	<testcase name="Error, then Fail, then Pass" timestamp="2023-05-04T15:11:07.692" time="0.442" tests="1" skipped="0" failures="0" errors="1">
+	<testcase name="Error, then Fail, then Pass" timestamp="2023-05-09T17:29:21.628" time="0.435" tests="1" skipped="0" failures="0" errors="1">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="72685834"></property>
 		<property name="dd_tags[perf.allocs]" value="1352181"></property>
-		<property name="dd_tags[perf.gctime]" value="0.004862583"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.370313457"></property>
+		<property name="dd_tags[perf.gctime]" value="0.004853958"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.36293654"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.run_time]" value="0.06726416899999998"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.06754441800000005"></property>
 		</properties>
-		<error message="Error during test at test/testfiles/_retry_tests.jl:24">Captured logs for test setup "StatefulSetup" (dependency of "Error, then Fail, then Pass") at test/testfiles/_retry_tests.jl:1 on worker 68950
+		<error message="Error during test at test/testfiles/_retry_tests.jl:24">Captured logs for test setup "StatefulSetup" (dependency of "Error, then Fail, then Pass") at test/testfiles/_retry_tests.jl:1 on worker 63497
 These are the test setup logs.
-Captured Logs for test item "Error, then Fail, then Pass" at test/testfiles/_retry_tests.jl:18 on worker 68950
+Captured Logs for test item "Error, then Fail, then Pass" at test/testfiles/_retry_tests.jl:18 on worker 63497
 These are the logs for run number: 1
-Error in testset "Error, then Fail, then Pass" on worker 68950:
+Error in testset "Error, then Fail, then Pass" on worker 63497:
 Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:24
   Test threw exception
   Expression: not_defined_err
@@ -53,167 +53,167 @@ Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tes
      @ /repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:24
 		</error>
 	</testcase>
-	<testcase name="Error, then Fail, then Pass" timestamp="2023-05-04T15:11:08.198" time="0.008" tests="1" skipped="0" failures="1" errors="0">
+	<testcase name="Error, then Fail, then Pass" timestamp="2023-05-09T17:29:22.123" time="0.008" tests="1" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="212803"></property>
 		<property name="dd_tags[perf.allocs]" value="3670"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.004825082"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.004507333"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.run_time]" value="0.003628626000000001"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.0037332090000000004"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:26">Captured logs for test setup "StatefulSetup" (dependency of "Error, then Fail, then Pass") at test/testfiles/_retry_tests.jl:1 on worker 68950
+		<error message="Test failed at test/testfiles/_retry_tests.jl:26">Captured logs for test setup "StatefulSetup" (dependency of "Error, then Fail, then Pass") at test/testfiles/_retry_tests.jl:1 on worker 63497
 These are the test setup logs.
-Captured Logs for test item "Error, then Fail, then Pass" at test/testfiles/_retry_tests.jl:18 on worker 68950
+Captured Logs for test item "Error, then Fail, then Pass" at test/testfiles/_retry_tests.jl:18 on worker 63497
 These are the logs for run number: 2
-Error in testset "Error, then Fail, then Pass" on worker 68950:
+Error in testset "Error, then Fail, then Pass" on worker 63497:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:26
   Expression: 2 + 2 == 5
    Evaluated: 4 == 5
 		</error>
 	</testcase>
-	<testcase name="Error, then Fail, then Pass" timestamp="2023-05-04T15:11:08.257" time="0.003" tests="1" skipped="0" failures="0" errors="0">
+	<testcase name="Error, then Fail, then Pass" timestamp="2023-05-09T17:29:22.18" time="0.003" tests="1" skipped="0" failures="0" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="100270"></property>
 		<property name="dd_tags[perf.allocs]" value="1675"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="8.4e-8"></property>
+		<property name="dd_tags[perf.compile_time]" value="1.66e-7"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.run_time]" value="0.003239582"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.0033688340000000002"></property>
 		</properties>
 	</testcase>
-	<testcase name="Has retries=4 and always fails" timestamp="2023-05-04T15:11:08.308" time="0.003" tests="1" skipped="0" failures="1" errors="0">
+	<testcase name="Has retries=4 and always fails" timestamp="2023-05-09T17:29:22.231" time="0.002" tests="1" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="73062"></property>
 		<property name="dd_tags[perf.allocs]" value="1137"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="8.3e-8"></property>
+		<property name="dd_tags[perf.compile_time]" value="2.08e-7"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.run_time]" value="0.003364917"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.00243075"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:35">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 68950
+		<error message="Test failed at test/testfiles/_retry_tests.jl:35">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 63497
 These are the test setup logs.
-No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:32 on worker 68950
-Error in testset "Has retries=4 and always fails" on worker 68950:
+No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:32 on worker 63497
+Error in testset "Has retries=4 and always fails" on worker 63497:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:35
   Expression: false
 		</error>
 	</testcase>
-	<testcase name="Has retries=4 and always fails" timestamp="2023-05-04T15:11:08.362" time="0.002" tests="1" skipped="0" failures="1" errors="0">
+	<testcase name="Has retries=4 and always fails" timestamp="2023-05-09T17:29:22.281" time="0.002" tests="1" skipped="0" failures="1" errors="0">
+		<properties>
+		<property name="dd_tags[perf.bytes]" value="73062"></property>
+		<property name="dd_tags[perf.allocs]" value="1137"></property>
+		<property name="dd_tags[perf.gctime]" value="0.0"></property>
+		<property name="dd_tags[perf.compile_time]" value="2.08e-7"></property>
+		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.0022761250000000004"></property>
+		</properties>
+		<error message="Test failed at test/testfiles/_retry_tests.jl:35">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 63497
+These are the test setup logs.
+No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:32 on worker 63497
+Error in testset "Has retries=4 and always fails" on worker 63497:
+Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:35
+  Expression: false
+		</error>
+	</testcase>
+	<testcase name="Has retries=4 and always fails" timestamp="2023-05-09T17:29:22.332" time="0.002" tests="1" skipped="0" failures="1" errors="0">
+		<properties>
+		<property name="dd_tags[perf.bytes]" value="73062"></property>
+		<property name="dd_tags[perf.allocs]" value="1137"></property>
+		<property name="dd_tags[perf.gctime]" value="0.0"></property>
+		<property name="dd_tags[perf.compile_time]" value="8.4e-8"></property>
+		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.002157541"></property>
+		</properties>
+		<error message="Test failed at test/testfiles/_retry_tests.jl:35">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 63497
+These are the test setup logs.
+No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:32 on worker 63497
+Error in testset "Has retries=4 and always fails" on worker 63497:
+Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:35
+  Expression: false
+		</error>
+	</testcase>
+	<testcase name="Has retries=4 and always fails" timestamp="2023-05-09T17:29:22.383" time="0.002" tests="1" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="73062"></property>
 		<property name="dd_tags[perf.allocs]" value="1137"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
 		<property name="dd_tags[perf.compile_time]" value="1.25e-7"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.run_time]" value="0.002144333"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.002307417"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:35">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 68950
+		<error message="Test failed at test/testfiles/_retry_tests.jl:35">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 63497
 These are the test setup logs.
-No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:32 on worker 68950
-Error in testset "Has retries=4 and always fails" on worker 68950:
+No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:32 on worker 63497
+Error in testset "Has retries=4 and always fails" on worker 63497:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:35
   Expression: false
 		</error>
 	</testcase>
-	<testcase name="Has retries=4 and always fails" timestamp="2023-05-04T15:11:08.411" time="0.002" tests="1" skipped="0" failures="1" errors="0">
+	<testcase name="Has retries=4 and always fails" timestamp="2023-05-09T17:29:22.433" time="0.002" tests="1" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="73062"></property>
 		<property name="dd_tags[perf.allocs]" value="1137"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="2.5e-7"></property>
+		<property name="dd_tags[perf.compile_time]" value="1.25e-7"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.run_time]" value="0.002227666"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.002202792"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:35">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 68950
+		<error message="Test failed at test/testfiles/_retry_tests.jl:35">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 63497
 These are the test setup logs.
-No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:32 on worker 68950
-Error in testset "Has retries=4 and always fails" on worker 68950:
+No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:32 on worker 63497
+Error in testset "Has retries=4 and always fails" on worker 63497:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:35
   Expression: false
 		</error>
 	</testcase>
-	<testcase name="Has retries=4 and always fails" timestamp="2023-05-04T15:11:08.461" time="0.002" tests="1" skipped="0" failures="1" errors="0">
+	<testcase name="Has retries=1 and always fails" timestamp="2023-05-09T17:29:22.483" time="0.002" tests="1" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="73062"></property>
 		<property name="dd_tags[perf.allocs]" value="1137"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="4.2e-8"></property>
+		<property name="dd_tags[perf.compile_time]" value="1.25e-7"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.run_time]" value="0.002120625"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.0021228329999999998"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:35">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 68950
+		<error message="Test failed at test/testfiles/_retry_tests.jl:41">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=1 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 63497
 These are the test setup logs.
-No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:32 on worker 68950
-Error in testset "Has retries=4 and always fails" on worker 68950:
-Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:35
+No Captured Logs for test item "Has retries=1 and always fails" at test/testfiles/_retry_tests.jl:38 on worker 63497
+Error in testset "Has retries=1 and always fails" on worker 63497:
+Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:41
   Expression: false
 		</error>
 	</testcase>
-	<testcase name="Has retries=4 and always fails" timestamp="2023-05-04T15:11:08.511" time="0.002" tests="1" skipped="0" failures="1" errors="0">
+	<testcase name="Has retries=1 and always fails" timestamp="2023-05-09T17:29:22.532" time="0.002" tests="1" skipped="0" failures="1" errors="0">
+		<properties>
+		<property name="dd_tags[perf.bytes]" value="73062"></property>
+		<property name="dd_tags[perf.allocs]" value="1137"></property>
+		<property name="dd_tags[perf.gctime]" value="0.0"></property>
+		<property name="dd_tags[perf.compile_time]" value="8.4e-8"></property>
+		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.002159833"></property>
+		</properties>
+		<error message="Test failed at test/testfiles/_retry_tests.jl:41">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=1 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 63497
+These are the test setup logs.
+No Captured Logs for test item "Has retries=1 and always fails" at test/testfiles/_retry_tests.jl:38 on worker 63497
+Error in testset "Has retries=1 and always fails" on worker 63497:
+Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:41
+  Expression: false
+		</error>
+	</testcase>
+	<testcase name="Has retries=1 and always fails" timestamp="2023-05-09T17:29:22.582" time="0.002" tests="1" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="73062"></property>
 		<property name="dd_tags[perf.allocs]" value="1137"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
 		<property name="dd_tags[perf.compile_time]" value="8.3e-8"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.run_time]" value="0.0021441249999999998"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.002272417"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:35">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 68950
+		<error message="Test failed at test/testfiles/_retry_tests.jl:41">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=1 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 63497
 These are the test setup logs.
-No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:32 on worker 68950
-Error in testset "Has retries=4 and always fails" on worker 68950:
-Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:35
-  Expression: false
-		</error>
-	</testcase>
-	<testcase name="Has retries=1 and always fails" timestamp="2023-05-04T15:11:08.559" time="0.003" tests="1" skipped="0" failures="1" errors="0">
-		<properties>
-		<property name="dd_tags[perf.bytes]" value="73062"></property>
-		<property name="dd_tags[perf.allocs]" value="1137"></property>
-		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="4.2e-8"></property>
-		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.run_time]" value="0.002795083"></property>
-		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:41">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=1 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 68950
-These are the test setup logs.
-No Captured Logs for test item "Has retries=1 and always fails" at test/testfiles/_retry_tests.jl:38 on worker 68950
-Error in testset "Has retries=1 and always fails" on worker 68950:
-Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:41
-  Expression: false
-		</error>
-	</testcase>
-	<testcase name="Has retries=1 and always fails" timestamp="2023-05-04T15:11:08.611" time="0.002" tests="1" skipped="0" failures="1" errors="0">
-		<properties>
-		<property name="dd_tags[perf.bytes]" value="73062"></property>
-		<property name="dd_tags[perf.allocs]" value="1137"></property>
-		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="4.2e-8"></property>
-		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.run_time]" value="0.002132792"></property>
-		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:41">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=1 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 68950
-These are the test setup logs.
-No Captured Logs for test item "Has retries=1 and always fails" at test/testfiles/_retry_tests.jl:38 on worker 68950
-Error in testset "Has retries=1 and always fails" on worker 68950:
-Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:41
-  Expression: false
-		</error>
-	</testcase>
-	<testcase name="Has retries=1 and always fails" timestamp="2023-05-04T15:11:08.661" time="0.002" tests="1" skipped="0" failures="1" errors="0">
-		<properties>
-		<property name="dd_tags[perf.bytes]" value="73062"></property>
-		<property name="dd_tags[perf.allocs]" value="1137"></property>
-		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="3.75e-7"></property>
-		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.run_time]" value="0.002228875"></property>
-		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:41">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=1 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 68950
-These are the test setup logs.
-No Captured Logs for test item "Has retries=1 and always fails" at test/testfiles/_retry_tests.jl:38 on worker 68950
-Error in testset "Has retries=1 and always fails" on worker 68950:
+No Captured Logs for test item "Has retries=1 and always fails" at test/testfiles/_retry_tests.jl:38 on worker 63497
+Error in testset "Has retries=1 and always fails" on worker 63497:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:41
   Expression: false
 		</error>


### PR DESCRIPTION
- suggestions for naming of this stat welcome! (it's `x = total_elapsed_time - compile_time - gc_time`)