### PR TITLE
Fix the GC.gc() invocation to do a full mark+sweep

### DIFF
--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -722,7 +722,9 @@ function runtestitem(ti::TestItem, ctx::TestContext; verbose_results::Bool=false
     push!(ti.testsets, ts)
     push!(ti.stats, stats)
     log_testitem_done(ti, ctx.ntestitems)
+    # It takes 2 GCs to do a full mark+sweep (the first one is a partial mark, full sweep, the next one is a full mark)
     GC.gc(true)
+    GC.gc(false)
     return TestItemResult(convert_results_to_be_transferrable(ts), stats)
 end
 


### PR DESCRIPTION
The `true` param tells the GC to do a full _sweep_, which clears out all the mark bits, and then the _next_ GC will be a full mark, since all the bits have been cleared.