### PR TITLE
Store task-local variable when running a testitem

### DIFF
--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -682,6 +682,10 @@ function runtestitem(ti::TestItem, ctx::TestContext; verbose_results::Bool=false
         end
     end
     Test.push_testset(ts)
+    # This allows us to identify if the code is running inside a `@testitem`, which is
+    # useful for e.g. macros that behave differently conditional on being in a `@testitem`.
+    # This was added so we could have a `@test_foo` macro exapnd to a `@testset` if already
+    # in a `@testitem` and expand to an `@testitem` otherwise.
     prev = get(task_local_storage(), :__TESTITEM_ACTIVE__, false)
     task_local_storage()[:__TESTITEM_ACTIVE__] = true
     try

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -682,6 +682,8 @@ function runtestitem(ti::TestItem, ctx::TestContext; verbose_results::Bool=false
         end
     end
     Test.push_testset(ts)
+    prev = get(task_local_storage(), :__TESTITEM_ACTIVE__, false)
+    task_local_storage()[:__TESTITEM_ACTIVE__] = true
     try
         for setup in ti.setups
             # TODO(nhd): Consider implementing some affinity to setups, so that we can
@@ -737,6 +739,7 @@ function runtestitem(ti::TestItem, ctx::TestContext; verbose_results::Bool=false
         # Make sure all test setup logs are commited to file
         foreach(ts->isassigned(ts.logstore) && flush(ts.logstore[]), ti.testsetups)
         ts1 = Test.pop_testset()
+        task_local_storage()[:__TESTITEM_ACTIVE__] = prev
         @assert ts1 === ts
         try
             finish_test && Test.finish(ts) # This will throw an exception if any of the tests failed.

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -106,6 +106,13 @@ end
     )
 end
 
+@testset "can identity if in a `@testitem`" begin
+    @testitem "testitem active" begin
+        @test get(task_local_storage(), :__TESTITEM_ACTIVE__, false)
+    end
+    @test !get(task_local_storage(), :__TESTITEM_ACTIVE__, false)
+end
+
 #=
 NOTE:
     These tests are disabled as we stopped using anonymous modules;


### PR DESCRIPTION
this allows you to identify if you're already in a testitem. this is a bit of a hack to support a use-case where we want a macro `@test_foo` to create a `@testset` if we are already in a `@testitem`, and otherwise create a `@testitem`.