### PR TITLE
Log capture also updates `_global_logstate`

### DIFF
--- a/test/integrationtests.jl
+++ b/test/integrationtests.jl
@@ -678,4 +678,18 @@ else
     @warn "Skipping tests with interactive threadpool support which requires Julia Version v1.9+" VERSION
 end
 
+@testset "_redirect_logs and custom loggers" begin
+    test_file_path = joinpath(TEST_FILES_DIR, "_logging_test.jl")
+    captured = IOCapture.capture(rethrow=Union{}) do
+        encased_testset(()->runtests(
+            "test/testfiles/_logging_test.jl",
+            nworkers=1,
+            logs=:issues,
+            worker_init_expr=:(using Logging; Logging.global_logger(Logging.ConsoleLogger(stderr)))
+        ))
+    end
+    # The test passes so we shouldn't see any logs
+    @test !occursin("Info message from testitem", captured.output)
+end
+
 end # integrationtests.jl testset

--- a/test/testfiles/_logging_test.jl
+++ b/test/testfiles/_logging_test.jl
@@ -1,0 +1,6 @@
+using ReTestItems
+
+@testitem "Test that uses a logger" begin
+    @info "Info message from testitem"
+    @test true
+end


### PR DESCRIPTION
By default, Julia creates a[ global logstate with a `SimpleLogger`](https://github.com/JuliaLang/julia/blob/master/base/logging.jl#L696) which, by default, uses a special stream -- [a closed IOBuffer](https://github.com/JuliaLang/julia/blob/master/base/logging.jl#L638-L639). Then when it comes to message handling, the default method [checks whether the stream is closed](https://github.com/JuliaLang/julia/blob/master/base/logging.jl#L675-L678) and if it is, it writes the message to the global `stderr`. But, if the user changes the global logger to a Logger, that doesn't dynamically look at what the current `stderr` is, our log capture wouldn't work because the Logger would still point to a stream it was created with.

So now we do the same thing as `Suppressor.jl` and eval a new global logstate into existence for the duration of log capture.