### PR TITLE
Support `_source` for manually setting location

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReTestItems"
 uuid = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
-version = "1.5.1"
+version = "1.6.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -224,6 +224,7 @@ macro testitem(nm, exs...)
     tags = Symbol[]
     setup = Any[]
     _run = true  # useful for testing `@testitem` itself
+    _source = QuoteNode(__source__)
     if length(exs) > 1
         kw_seen = Set{Symbol}()
         for ex in exs[1:end-1]
@@ -247,6 +248,9 @@ macro testitem(nm, exs...)
             elseif kw == :_run
                 _run = ex.args[2]
                 @assert _run isa Bool "`_run` keyword must be passed a `Bool`"
+            elseif kw == :_source
+                _source = ex.args[2]
+                @assert isa(_source, Union{QuoteNode,Expr})
             else
                 error("unknown `@testitem` keyword arg `$(ex.args[1])`")
             end
@@ -259,8 +263,8 @@ macro testitem(nm, exs...)
     ti = gensym(:ti)
     esc(quote
         let $ti = $TestItem(
-            Ref(0), $nm, $tags, $default_imports, $setup, $retries,
-            $(String(__source__.file)), $(__source__.line),
+            $Ref(0), $nm, $tags, $default_imports, $setup, $retries,
+            $String($_source.file), $_source.line,
             $gettls(:__RE_TEST_PROJECT__, "."),
             $q,
         )

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -206,16 +206,16 @@ end
     end
 end
 
-# Macros must be defined at global-scope (outside `@testset`)
-macro foo_test(name)
-    _source = QuoteNode(__source__)
-    quote
-        @testitem $name _source=$_source _run=false begin
-            @test true
+@testset "manually specify `source` location" begin
+    # eval because macros must be defined at global-scope
+    @eval macro foo_test(name)
+        _source = QuoteNode(__source__)
+        quote
+            @testitem $name _source=$_source _run=false begin
+                @test true
+            end
         end
     end
-end
-@testset "manually specify `source` location" begin
     # this would point to the definition a few lines up, if we weren't correctly setting the
     # source location manually
     line = @__LINE__() + 1

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -207,16 +207,7 @@ end
 end
 
 @testset "manually specify `source` location" begin
-    # eval because macros must be defined at global-scope
-    @eval macro foo_test(name)
-        _source = QuoteNode(__source__)
-        quote
-            @testitem $name _source=$_source _run=false begin
-                @test true
-            end
-        end
-    end
-    # this would point to the definition a few lines up, if we weren't correctly setting the
+    # this would point to the definition in runtests.jl, if we weren't correctly setting the
     # source location manually
     line = @__LINE__() + 1
     ti = @foo_test "one"

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -206,6 +206,28 @@ end
     end
 end
 
+# Macros must be defined at global-scope (outside `@testset`)
+macro foo_test(name)
+    _source = QuoteNode(__source__)
+    quote
+        @testitem $name _source=$_source _run=false begin
+            @test true
+        end
+    end
+end
+@testset "manually specify `source` location" begin
+    # this would point to the definition a few lines up, if we weren't correctly setting the
+    # source location manually
+    line = @__LINE__() + 1
+    ti = @foo_test "one"
+    @test ti.file == @__FILE__
+    @test ti.line == line
+
+    ti = @testitem "two" _source=LineNumberNode(42, "foo.jl") _run=false begin; end;
+    @test ti.file == "foo.jl"
+    @test ti.line == 42
+end
+
 #=
 NOTE:
     These tests are disabled as we stopped using anonymous modules;

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,15 @@
 using ReTestItems, Test, Pkg
 
+# Used by test/macros.jl, but macros must be defined at global scope (outside `@testset).
+macro foo_test(name)
+    _source = QuoteNode(__source__)
+    quote
+        @testitem $name _source=$_source _run=false begin
+            @test true
+        end
+    end
+end
+
 @testset "ReTestItems" verbose=true begin
     # track all workers every created
     ALL_WORKERS = []


### PR DESCRIPTION
Similar in spirit to https://github.com/JuliaTesting/ReTestItems.jl/pull/65: Useful for if you've a macro the expands to a `@testitem` and you want to pass in where call-site location, so that you get accurate _call site_ file/line info (rather than the macro definition site)
```
START test item "TI2" at test/callsite.jl:42
```

as a silly example:
```julia
macro foo_test(name)
    _source = QuoteNode(__source__)
    quote
        @testitem $name _source=$_source begin
            @test true
        end
    end
end
```