### PR TITLE
Fix weird syntax in tests

### DIFF
--- a/test/internals.jl
+++ b/test/internals.jl
@@ -11,7 +11,7 @@ using ReTestItems
     # let's test this exhaustively for 1-10 testitems across 1-10 workers.
     for nworkers in 1:10
         for nitems in 1:10
-            testitems = [@testitem "ti-$i" _run=false begin; end; for i in 1:nitems]
+            testitems = [@testitem("ti-$i", _run=false, begin end) for i in 1:nitems]
             starts = get_starting_testitems(TestItems(graph, testitems, 0), nworkers)
             startitems = [x for x in starts if !isnothing(x)]
             @test length(starts) == nworkers


### PR DESCRIPTION
Found as part of testing for JuliaLang/julia#46372 - JuliaSyntax.jl rejects this weird syntax.  The reference parser allows it, but that kind of seems unintentional: Having a semicolon within `[]` would normally imply `vcat`, but having a semicolon followed by a `for` to make it into a comprehension?  That's just weird and maybe unintended ? :-)