### PR TITLE
Move GC run outside of `runtestitem`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReTestItems"
 uuid = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
-version = "1.7.0"
+version = "1.7.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -306,7 +306,10 @@ function _runtests_in_current_env(
                         end
                         break
                     end
-                    run_full_gc()
+                    # It takes 2 GCs to do a full mark+sweep
+                    # (the first one is a partial mark, full sweep, the next one is a full mark).
+                    GC.gc(true)
+                    GC.gc(false)
                 end
             end
         elseif !isempty(testitems.testitems)
@@ -416,7 +419,7 @@ function start_and_manage_worker(
                 print_errors_and_captured_logs(testitem, nretries + 1; logs)
                 report_empty_testsets(testitem, ts)
                 # Run GC to free memory on the worker before next testitem.
-                remote_fetch(worker, :(run_full_gc()))
+                remote_fetch(worker, :(GC.gc(true); GC.gc(false))
                 # If the result isn't a pass, we throw to go to the outer try-catch
                 throw_if_failed(ts)
                 testitem = next_testitem(testitems, testitem.id[])
@@ -825,10 +828,6 @@ function runtestitem(
     log_testitem_done(ti, ctx.ntestitems)
     return TestItemResult(convert_results_to_be_transferrable(ts), stats)
 end
-
-# It takes 2 GCs to do a full mark+sweep
-# (the first one is a partial mark, full sweep, the next one is a full mark).
-run_full_gc() = GC.gc(true); GC.gc(false)
 
 # copied from XUnit.jl
 function convert_results_to_be_transferrable(ts::Test.AbstractTestSet)

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -802,7 +802,7 @@ function runtestitem(
             with_source_path(() -> Core.eval(Main, mod_expr), ti.file)
             nothing # return nothing as the first return value of @timed_with_compilation
         end
-        @debugv 1 "Test item $(repr(name)) done$(_on_worker())."
+        @debugv 1 "Done evaluating test item $(repr(name))$(_on_worker())."
     catch err
         err isa InterruptException && rethrow()
         # Handle exceptions thrown outside a `@test` in the body of the @testitem:
@@ -825,8 +825,10 @@ function runtestitem(
     @debugv 1 "Test item $(repr(name)) done$(_on_worker())."
     push!(ti.testsets, ts)
     push!(ti.stats, stats)
+    @debugv 2 "Converting results for test item $(repr(name))$(_on_worker())."
+    res = convert_results_to_be_transferrable(ts)
     log_testitem_done(ti, ctx.ntestitems)
-    return TestItemResult(convert_results_to_be_transferrable(ts), stats)
+    return TestItemResult(res, stats)
 end
 
 # copied from XUnit.jl

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -432,14 +432,15 @@ function start_and_manage_worker(
                 rethrow()
             end
 
-            if !(e isa TestSetFailure)
+            if e isa TestSetFailure
+                # The worker will be re-used for retrying or next testitem
+                @debugv 2 "Triggering GC on $worker"
+                remote_eval(worker, :(run_full_gc()))
+            else
                 println(DEFAULT_STDOUT[])
                 # Explicitly show captured logs or say there weren't any in case we're about
                 # to terminte the worker
                 _print_captured_logs(DEFAULT_STDOUT[], testitem, nretries + 1)
-                @debugv 2 "Triggering GC on $worker"
-                # Run GC to free memory on the worker before retrying or next testitem.
-                remote_eval(worker, :(run_full_gc()))
             end
 
             if e isa TimeoutException

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -409,9 +409,9 @@ function start_and_manage_worker(
             try
                 # if we get a WorkerTerminatedException or TimeoutException
                 # then wait will throw here and we fall through to the outer try-catch
-                @debugv 2 "Waiting on test item result"
+                @debugv 2 "Waiting on result for test item $(repr(testitem.name))"
                 testitem_result = @lock cond wait(cond)
-                @debugv 2 "Recieved test item result"
+                @debugv 2 "Recieved result for test item $(repr(testitem.name))"
                 ts = testitem_result.testset
                 push!(testitem.testsets, ts)
                 push!(testitem.stats, testitem_result.stats)

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -831,18 +831,15 @@ function runtestitem(
     return TestItemResult(res, stats)
 end
 
-# copied from XUnit.jl
 function convert_results_to_be_transferrable(ts::Test.AbstractTestSet)
-    results_copy = copy(ts.results)
-    empty!(ts.results)
-    for t in results_copy
-        push!(ts.results, convert_results_to_be_transferrable(t))
+    for (i, res) in enumerate(ts.results)
+        ts.results[i] = convert_results_to_be_transferrable(res)
     end
     return ts
 end
 
 function convert_results_to_be_transferrable(res::Test.Pass)
-    if res.test_type == :test_throws
+    if res.test_type === :test_throws
         # A passed `@test_throws` contains the stacktrace for the (correctly) thrown exception
         # This exception might contain references to some types that are not available
         # on other processes (e.g., the master process that consolidates the results)

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -411,7 +411,7 @@ function start_and_manage_worker(
                 # then wait will throw here and we fall through to the outer try-catch
                 @debugv 2 "Waiting on result for test item $(repr(testitem.name))"
                 testitem_result = @lock cond wait(cond)
-                @debugv 2 "Recieved result for test item $(repr(testitem.name))"
+                @debugv 2 "Received result for test item $(repr(testitem.name))"
                 ts = testitem_result.testset
                 push!(testitem.testsets, ts)
                 push!(testitem.stats, testitem_result.stats)

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -412,13 +412,13 @@ function start_and_manage_worker(
                 @debugv 2 "Waiting on test item result"
                 testitem_result = @lock cond wait(cond)
                 @debugv 2 "Recieved test item result"
-                @debugv 2 "Triggering GC on $worker"
                 ts = testitem_result.testset
                 push!(testitem.testsets, ts)
                 push!(testitem.stats, testitem_result.stats)
                 print_errors_and_captured_logs(testitem, nretries + 1; logs)
                 report_empty_testsets(testitem, ts)
                 # Run GC to free memory on the worker before next testitem.
+                @debugv 2 "Running GC on $worker"
                 remote_fetch(worker, :(GC.gc(true); GC.gc(false)))
                 # If the result isn't a pass, we throw to go to the outer try-catch
                 throw_if_failed(ts)

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -410,13 +410,13 @@ function start_and_manage_worker(
                 testitem_result = @lock cond wait(cond)
                 @debugv 2 "Recieved test item result"
                 @debugv 2 "Triggering GC on $worker"
-                # Run GC to free memory on the worker before next testitem.
-                remote_eval(worker, :(run_full_gc()))
                 ts = testitem_result.testset
                 push!(testitem.testsets, ts)
                 push!(testitem.stats, testitem_result.stats)
                 print_errors_and_captured_logs(testitem, nretries + 1; logs)
                 report_empty_testsets(testitem, ts)
+                # Run GC to free memory on the worker before next testitem.
+                remote_eval(worker, :(run_full_gc()))
                 # If the result isn't a pass, we throw to go to the outer try-catch
                 throw_if_failed(ts)
                 testitem = next_testitem(testitems, testitem.id[])

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -416,7 +416,7 @@ function start_and_manage_worker(
                 print_errors_and_captured_logs(testitem, nretries + 1; logs)
                 report_empty_testsets(testitem, ts)
                 # Run GC to free memory on the worker before next testitem.
-                remote_eval(worker, :(run_full_gc()))
+                remote_fetch(worker, :(run_full_gc()))
                 # If the result isn't a pass, we throw to go to the outer try-catch
                 throw_if_failed(ts)
                 testitem = next_testitem(testitems, testitem.id[])

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -419,7 +419,7 @@ function start_and_manage_worker(
                 print_errors_and_captured_logs(testitem, nretries + 1; logs)
                 report_empty_testsets(testitem, ts)
                 # Run GC to free memory on the worker before next testitem.
-                remote_fetch(worker, :(GC.gc(true); GC.gc(false))
+                remote_fetch(worker, :(GC.gc(true); GC.gc(false)))
                 # If the result isn't a pass, we throw to go to the outer try-catch
                 throw_if_failed(ts)
                 testitem = next_testitem(testitems, testitem.id[])


### PR DESCRIPTION
- So that GC isn't included in the time allowed for a testitem to run (when a timeout is set). (fix #79)
- Also optimise `convert_results_to_be_transferrable` to further reduce time between test done and it being returned to the coordinator process

~Is `remote_eval`'ing GC in between `remote_eval(w, :(runtestitem(...)))` sufficient for it to guarantee GC will _run_ in between the `runtestitem`, or do we need the coordinator to be `wait`ing on it before the next `runtestitem` to be sure?~ We have to `wait` it seems 😞 