### PR TITLE
Replace Condition with Channel

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReTestItems"
 uuid = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
-version = "1.7.1"
+version = "1.7.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"


### PR DESCRIPTION
- fix https://github.com/JuliaTesting/ReTestItems.jl/issues/84

The previous implementation was racy, because the testitem run could complete and `notify` the Condition before we had started to `wait` on the Condition, in which case when we did then `wait` we would be waiting for the _next_ notify which would be from the `Timer`