### PR TITLE
Use a Channel to safely populate setups Dict

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReTestItems"
 uuid = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
-version = "1.8.0"
+version = "1.8.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -561,7 +561,7 @@ function include_testfiles!(project_name, projectfile, paths, shouldrun, report:
     subproject_root = nothing  # don't recurse into directories with their own Project.toml.
     root_node = DirNode(project_name; report, verbose=true)
     dir_nodes = Dict{String, DirNode}()
-    # setup_channel is populated in store_test_item_setup when we expand a @testsetup
+    # setup_channel is populated in store_test_setup when we expand a @testsetup
     # we set it below in tls as __RE_TEST_SETUPS__ for each included file
     setup_channel = Channel{Pair{Symbol, TestSetup}}(Inf)
     setup_task = @spawn begin

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -295,11 +295,11 @@ function store_test_item_setup(ti::Union{TestItem, TestSetup})
     elseif ti isa TestSetup
         @debugv 2 "expanding test setup: `$(ti.name)`"
         # if we're not in a runtests context, add the test setup to the global dict
-        setups = get(tls, :__RE_TEST_SETUPS__, GLOBAL_TEST_SETUPS_FOR_TESTING)
-        if haskey(setups, ti.name)
-            @warn "Encountered duplicate @testsetup with name: `$(ti.name)`. Replacing..."
+        if haskey(tls, :__RE_TEST_SETUPS__)
+            put!(tls[:__RE_TEST_SETUPS__], ti.name => ti)
+        else
+            GLOBAL_TEST_SETUPS_FOR_TESTING[ti.name] = ti
         end
-        setups[ti.name] = ti
     end
     return ti
 end


### PR DESCRIPTION
Spawn a task to populate the shared `Dict` of test-setups, rather than writing to a shared `Dict` in parallel which can result in data being lost. 

```julia
julia> D = Dict{Int,Int}()
Dict{Int64, Int64}()

julia> @sync for i in 1:100_000
           Threads.@spawn $D[$i] = $i
       end

julia> length(D)
99377
```

Before, we would 
- Spawn a bunch of tasks to include files in parallel, with all of them sharing the same reference to setups **Dict**:   
  - https://github.com/JuliaTesting/ReTestItems.jl/blob/b1f3a66d50f41ac1ed8f908bb3cc03c39a86e2a1/src/ReTestItems.jl#L598-L608
- During the include, we eval the testsetup macro which calls `store_test_item_setup`
  - https://github.com/JuliaTesting/ReTestItems.jl/blob/f5c6c9133448a2a2f7055f12878825354dbb98c4/src/macros.jl#L56-L57
- In that function, we populate the shared setups **Dict** (without locking)
  - https://github.com/JuliaTesting/ReTestItems.jl/blob/f5c6c9133448a2a2f7055f12878825354dbb98c4/src/macros.jl#L293

Now, we
- Spawn a bunch of tasks to include files in parallel, with all of them sharing the same reference to setups **Channel**
- (as before) During the include, we eval the testsetup macro which calls `store_test_item_setup` 
- In that function, we put the setups on the shared **Channel**
- ALSO Spawn a "setup" task that takes items of the Channel and populates a Dict
- after the `@sync` block with all files-include tasks has completed, we `close` the Channel and `fetch` the **Dict** from the "setup" task

Also splits `store_test_item_setup` into `store_test_item` and `store_test_setup` since really they're different functions.

Thanks to @Drvi for helping figure this one out