### PR TITLE
Throw if a file contains multiple testitems with the same name

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReTestItems"
 uuid = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
-version = "1.7.2"
+version = "1.8.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -593,11 +593,12 @@ function include_testfiles!(project_name, projectfile, paths, shouldrun, report:
             end
             fpath = relpath(filepath, project_root)
             file_node = FileNode(fpath, shouldrun; report, verbose=true)
+            testitem_names = Set{String}() # to enforce that names in the same file are unique
             push!(dir_node, file_node)
             @debugv 1 "Including test items from file `$filepath`"
             @spawn begin
                 task_local_storage(:__RE_TEST_RUNNING__, true) do
-                    task_local_storage(:__RE_TEST_ITEMS__, $file_node) do
+                    task_local_storage(:__RE_TEST_ITEMS__, ($file_node, $testitem_names)) do
                         task_local_storage(:__RE_TEST_PROJECT__, $(project_root)) do
                             task_local_storage(:__RE_TEST_SETUPS__, $setups) do
                                 checked_include(Main, $filepath)

--- a/test/integrationtests.jl
+++ b/test/integrationtests.jl
@@ -700,4 +700,19 @@ end
     @test_throws expected runtests(joinpath(TEST_FILES_DIR, "_misuse_file3_test.jl"))
 end
 
+@testset "Duplicate names in same file throws" begin
+    file = joinpath(TEST_FILES_DIR, "_duplicate_names_test.jl")
+    expected_msg = Regex("Duplicate test item name `dup` in file `test/testfiles/_duplicate_names_test.jl` at line 4")
+    @test_throws expected_msg runtests(file; nworkers=0)
+    @test_throws expected_msg runtests(file; nworkers=1)
+end
+@testset "Duplicate names in different files allowed" begin
+    file1 = joinpath(TEST_FILES_DIR, "_same_name1_test.jl")
+    file2 = joinpath(TEST_FILES_DIR, "_same_name2_test.jl")
+    for nworkers in (0, 1)
+        results = encased_testset(() -> runtests(file1, file2; nworkers))
+        @test n_tests(results) == 2
+    end
+end
+
 end # integrationtests.jl testset

--- a/test/testfiles/_duplicate_names_test.jl
+++ b/test/testfiles/_duplicate_names_test.jl
@@ -1,0 +1,6 @@
+@testitem "dup" begin
+    @test true
+end
+@testitem "dup" begin
+    @test true
+end

--- a/test/testfiles/_same_name1_test.jl
+++ b/test/testfiles/_same_name1_test.jl
@@ -1,0 +1,4 @@
+# must match name of testitem in _same_name2_test.jl
+@testitem "same name" begin
+    @test true
+end

--- a/test/testfiles/_same_name2_test.jl
+++ b/test/testfiles/_same_name2_test.jl
@@ -1,0 +1,4 @@
+# must match name of testitem in _same_name1_test.jl
+@testitem "same name" begin
+    @test true
+end


### PR DESCRIPTION
Test reports cannot distinguish test items in the same file with the same name i.e. it cannot distinguish two tests that each ran once from once test that ran twice, if the name and file are the same. Likewise `runtests(file; name)` cannot distinguish either. At RAI we've not seen any deliberate uses of duplicate names, only unintended uses. Overall, it seems better to disallow this by throwing rather than allowing them but then having ambiguity in the report and `runtests`.

cc @mcmcgrath13 