### PR TITLE
Record errors before logs in XML reports

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReTestItems"
 uuid = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
-version = "1.9.0"
+version = "1.10.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/junit_xml.jl
+++ b/src/junit_xml.jl
@@ -55,7 +55,7 @@ function JUnitTestCase(ti::TestItem, run_number::Int)
         message = nothing
     else
         io = IOBuffer()
-        print_errors_and_captured_logs(io, ti, run_number)
+        print_errors_and_captured_logs(io, ti, run_number; errors_first=true)
         logs = take!(io)
         message = _error_message(ts, ti)
     end

--- a/src/log_capture.jl
+++ b/src/log_capture.jl
@@ -147,7 +147,7 @@ _mem_watermark() = string(
 )
 
 """
-    print_errors_and_captured_logs(ti::TestItem, run_number::Int; logs=:batched)
+    print_errors_and_captured_logs(ti::TestItem, run_number::Int; logs=:batched, errors_first=false)
 
 When a testitem doesn't succeed, we print the corresponding error/failure reports
 from the testset and any logs that we captured while the testitem was eval()'d.
@@ -155,6 +155,9 @@ from the testset and any logs that we captured while the testitem was eval()'d.
 For `:eager` mode of `logs` we don't print any logs as they bypass log capture. `:batched`
 means we print logs even for passing test items, whereas `:issues` means we are only printing
 captured logs if there were any errors or failures.
+
+If `errors_first=true`, then the test errors are printed first and the logs second.
+The default `errors_first=false`, prints the logs firsts.
 
 Nothing is printed when no logs were captures and no failures or errors occured.
 """

--- a/test/references/junit_xml_test_report.xml
+++ b/test/references/junit_xml_test_report.xml
@@ -1,64 +1,63 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites timestamp="2023-05-09T17:27:12.837" time="0.58" tests="13" skipped="3" failures="3" errors="2">
-<testsuite name="test/testfiles/_junit_xml_test.jl" timestamp="2023-05-09T17:27:12.837" time="0.58" tests="13" skipped="3" failures="3" errors="2">
-	<testcase name="testitem1" timestamp="2023-05-09T17:27:12.837" time="0.065" tests="2" skipped="0" failures="1" errors="0">
+<testsuites timestamp="2023-06-21T18:19:11.24" time="0.539" tests="13" skipped="3" failures="3" errors="2">
+<testsuite name="test/testfiles/_junit_xml_test.jl" timestamp="2023-06-21T18:19:11.24" time="0.539" tests="13" skipped="3" failures="3" errors="2">
+	<testcase name="testitem1" timestamp="2023-06-21T18:19:11.24" time="0.052" tests="2" skipped="0" failures="1" errors="0">
 		<properties>
-		<property name="dd_tags[perf.bytes]" value="4331408"></property>
-		<property name="dd_tags[perf.allocs]" value="74125"></property>
+		<property name="dd_tags[perf.bytes]" value="4851625"></property>
+		<property name="dd_tags[perf.allocs]" value="82688"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.055512587"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.042752083"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.0041838299999999995"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.004830874999999998"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_junit_xml_test.jl:4">No Captured Logs for test item "testitem1" at test/testfiles/_junit_xml_test.jl:2 on worker 61736
-Error in testset "testitem1" on worker 61736:
+		<error message="Test failed at test/testfiles/_junit_xml_test.jl:4">Error in testset "testitem1" on worker 42127:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:4
   Expression: 2 == 3
    Evaluated: 2 == 3
+No Captured Logs for test item "testitem1" at test/testfiles/_junit_xml_test.jl:2 on worker 42127
 		</error>
 	</testcase>
-	<testcase name="testitem2" timestamp="2023-05-09T17:27:13.063" time="0.032" tests="3" skipped="0" failures="1" errors="1">
+	<testcase name="testitem2" timestamp="2023-06-21T18:19:11.423" time="0.031" tests="3" skipped="0" failures="1" errors="1">
 		<properties>
-		<property name="dd_tags[perf.bytes]" value="3213927"></property>
-		<property name="dd_tags[perf.allocs]" value="57359"></property>
+		<property name="dd_tags[perf.bytes]" value="3214759"></property>
+		<property name="dd_tags[perf.allocs]" value="57345"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.027375085"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.027323084"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.004111123000000001"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.003977082999999996"></property>
 		</properties>
-		<error message="Multiple errors for test item at test/testfiles/_junit_xml_test.jl:8">No Captured Logs for test item "testitem2" at test/testfiles/_junit_xml_test.jl:8 on worker 61736
-Error in testset "inner testset" on worker 61736:
+		<error message="Multiple errors for test item at test/testfiles/_junit_xml_test.jl:8">Error in testset "inner testset" on worker 42127:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:11
   Expression: 4 == 5
    Evaluated: 4 == 5
-Error in testset "inner testset" on worker 61736:
+Error in testset "inner testset" on worker 42127:
 Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:12
   Expression evaluated to non-Boolean
   Expression: not a bool
        Value: "not a bool"
+No Captured Logs for test item "testitem2" at test/testfiles/_junit_xml_test.jl:8 on worker 42127
 		</error>
 	</testcase>
-	<testcase name="testitem3" timestamp="2023-05-09T17:27:13.15" time="0.002" tests="2" skipped="0" failures="0" errors="0">
+	<testcase name="testitem3" timestamp="2023-06-21T18:19:11.458" time="0.002" tests="2" skipped="0" failures="0" errors="0">
 		<properties>
-		<property name="dd_tags[perf.bytes]" value="70286"></property>
-		<property name="dd_tags[perf.allocs]" value="1176"></property>
+		<property name="dd_tags[perf.bytes]" value="71118"></property>
+		<property name="dd_tags[perf.allocs]" value="1162"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="1.67e-7"></property>
+		<property name="dd_tags[perf.compile_time]" value="2.08e-7"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.0022919999999999998"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.002104084"></property>
 		</properties>
 	</testcase>
-	<testcase name="testitem4" timestamp="2023-05-09T17:27:13.201" time="0.469" tests="1" skipped="0" failures="0" errors="1">
+	<testcase name="testitem4" timestamp="2023-06-21T18:19:11.461" time="0.442" tests="1" skipped="0" failures="0" errors="1">
 		<properties>
-		<property name="dd_tags[perf.bytes]" value="78752010"></property>
-		<property name="dd_tags[perf.allocs]" value="1462662"></property>
-		<property name="dd_tags[perf.gctime]" value="0.005105333"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.392469709"></property>
+		<property name="dd_tags[perf.bytes]" value="78309834"></property>
+		<property name="dd_tags[perf.allocs]" value="1456708"></property>
+		<property name="dd_tags[perf.gctime]" value="0.005731084"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.37133442"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.071699124"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.06502566199999998"></property>
 		</properties>
-		<error message="Error during test at test/testfiles/_junit_xml_test.jl:24">No Captured Logs for test item "testitem4" at test/testfiles/_junit_xml_test.jl:23 on worker 61736
-Error in testset "nested testset" on worker 61736:
+		<error message="Error during test at test/testfiles/_junit_xml_test.jl:24">Error in testset "nested testset" on worker 42127:
 Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:24
   Got exception outside of a @test
   UndefVarError: x not defined
@@ -71,103 +70,76 @@ Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml
       @ /repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:25
     [4] eval
       @ ./boot.jl:368 [inlined]
-    [5] #81
-      @ /repos/ReTestItems.jl/src/ReTestItems.jl:701 [inlined]
-    [6] with_source_path(f::ReTestItems.var"#81#84"{Expr}, path::String)
-      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:584
-    [7] #80
-      @ /repos/ReTestItems.jl/src/ReTestItems.jl:701 [inlined]
-    [8] redirect_stdio(f::ReTestItems.var"#80#83"{TestItem, Expr}; stdin::Nothing, stderr::IOContext{IOStream}, stdout::IOContext{IOStream})
+    [5] #79
+      @ /repos/ReTestItems.jl/src/ReTestItems.jl:816 [inlined]
+    [6] with_source_path(f::ReTestItems.var"#79#82"{Expr}, path::String)
+      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:688
+    [7] #78
+      @ /repos/ReTestItems.jl/src/ReTestItems.jl:816 [inlined]
+    [8] redirect_stdio(f::ReTestItems.var"#78#81"{TestItem, Expr}; stdin::Nothing, stderr::IOContext{IOStream}, stdout::IOContext{IOStream})
       @ Base ./stream.jl:1411
-    [9] _redirect_logs(f::ReTestItems.var"#80#83"{TestItem, Expr}, target::IOStream)
-      @ ReTestItems /repos/ReTestItems.jl/src/log_capture.jl:111
+    [9] _redirect_logs(f::ReTestItems.var"#78#81"{TestItem, Expr}, target::IOStream)
+      @ ReTestItems /repos/ReTestItems.jl/src/log_capture.jl:122
    [10] #27
       @ /repos/ReTestItems.jl/src/log_capture.jl:107 [inlined]
-   [11] open(::ReTestItems.var"#27#28"{ReTestItems.var"#80#83"{TestItem, Expr}}, ::String, ::Vararg{String}; kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
+   [11] open(::ReTestItems.var"#27#28"{ReTestItems.var"#78#81"{TestItem, Expr}}, ::String, ::Vararg{String}; kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
       @ Base ./io.jl:384
    [12] open
       @ ./io.jl:381 [inlined]
    [13] _redirect_logs
       @ /repos/ReTestItems.jl/src/log_capture.jl:107 [inlined]
    [14] macro expansion
-      @ /repos/ReTestItems.jl/src/macros.jl:81 [inlined]
-   [15] runtestitem(ti::TestItem, ctx::ReTestItems.TestContext; verbose_results::Bool, finish_test::Bool, logs::Symbol)
-      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:700
-   [16] _runtests_in_current_env(shouldrun::Function, paths::Tuple{String}, projectfile::String, nworkers::Int64, nworker_threads::Int64, worker_init_expr::Expr, testitem_timeout::Int64, retries::Int64, verbose_results::Bool, debug::Int64, report::Bool, logs::Symbol)
-      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:254
-   [17] #48
-      @ /repos/ReTestItems.jl/src/ReTestItems.jl:219 [inlined]
-   [18] (::TestEnv.var"#2#3"{ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}})()
-      @ TestEnv /.julia/packages/TestEnv/bSUAo/src/activate_do.jl:19
-   [19] withenv(::TestEnv.var"#2#3"{ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, ::Pair{String, String}, ::Vararg{Pair{String}})
-      @ Base ./env.jl:172
-   [20] (::Pkg.Operations.var"#107#112"{String, Bool, Bool, Bool, TestEnv.var"#2#3"{ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, Pkg.Types.PackageSpec})()
-      @ Pkg.Operations /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:1619
-   [21] with_temp_env(fn::Pkg.Operations.var"#107#112"{String, Bool, Bool, Bool, TestEnv.var"#2#3"{ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, Pkg.Types.PackageSpec}, temp_env::String)
-      @ Pkg.Operations /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:1493
-   [22] (::Pkg.Operations.var"#105#110"{Nothing, Bool, Bool, Bool, TestEnv.var"#2#3"{ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, Pkg.Types.Context, Pkg.Types.PackageSpec, String, Pkg.Types.Project, String})(tmp::String)
-      @ Pkg.Operations /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:1582
-   [23] mktempdir(fn::Pkg.Operations.var"#105#110"{Nothing, Bool, Bool, Bool, TestEnv.var"#2#3"{ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, Pkg.Types.Context, Pkg.Types.PackageSpec, String, Pkg.Types.Project, String}, parent::String; prefix::String)
-      @ Base.Filesystem ./file.jl:764
-   [24] mktempdir(fn::Function, parent::String) (repeats 2 times)
-      @ Base.Filesystem ./file.jl:760
-   [25] sandbox(fn::Function, ctx::Pkg.Types.Context, target::Pkg.Types.PackageSpec, target_path::String, sandbox_path::String, sandbox_project_override::Pkg.Types.Project; preferences::Nothing, force_latest_compatible_version::Bool, allow_earlier_backwards_compatible_versions::Bool, allow_reresolve::Bool)
-      @ Pkg.Operations /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:1540
-   [26] sandbox
-      @ /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:1531 [inlined]
-   [27] activate(f::ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}, pkg::String)
-      @ TestEnv /.julia/packages/TestEnv/bSUAo/src/activate_do.jl:17
-   [28] activate(f::Function)
-      @ TestEnv /.julia/packages/TestEnv/bSUAo/src/activate_do.jl:13
-   [29] #47
-      @ /repos/ReTestItems.jl/src/ReTestItems.jl:218 [inlined]
-   [30] activate(f::ReTestItems.var"#47#50"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}, new_project::String)
-      @ Pkg.API /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/API.jl:1707
-   [31] (::ReTestItems.var"#46#49"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String})()
-      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:217
-   [32] with_logstate(f::Function, logstate::Any)
+      @ /repos/ReTestItems.jl/src/macros.jl:82 [inlined]
+   [15] runtestitem(ti::TestItem, ctx::ReTestItems.TestContext; logs::Symbol, verbose_results::Bool, finish_test::Bool)
+      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:815
+   [16] _runtests_in_current_env(shouldrun::Function, paths::Tuple{String}, projectfile::String, nworkers::Int64, nworker_threads::String, worker_init_expr::Expr, testitem_timeout::Int64, retries::Int64, verbose_results::Bool, debug::Int64, report::Bool, logs::Symbol)
+      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:296
+   [17] (::ReTestItems.var"#46#47"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, String, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String})()
+      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:260
+   [18] with_logstate(f::Function, logstate::Any)
       @ Base.CoreLogging ./logging.jl:511
-   [33] with_logger
+   [19] with_logger
       @ ./logging.jl:623 [inlined]
-   [34] _runtests(shouldrun::Function, paths::Tuple{String}, nworkers::Int64, nworker_threads::Int64, worker_init_expr::Expr, testitem_timeout::Int64, retries::Int64, verbose_results::Bool, debug::Int64, report::Bool, logs::Symbol)
-      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:210
-   [35] runtests(shouldrun::typeof(ReTestItems.default_shouldrun), paths::String; nworkers::Int64, nworker_threads::Int64, worker_init_expr::Expr, testitem_timeout::Int64, retries::Int64, debug::Int64, name::Nothing, tags::Nothing, report::Bool, logs::Symbol, verbose_results::Bool)
-      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:190
-   [36] #runtests#37
-      @ /repos/ReTestItems.jl/src/ReTestItems.jl:140 [inlined]
-   [37] top-level scope
+   [20] _runtests(shouldrun::Function, paths::Tuple{String}, nworkers::Int64, nworker_threads::String, worker_init_expr::Expr, testitem_timeout::Int64, retries::Int64, verbose_results::Bool, debug::Int64, report::Bool, logs::Symbol)
+      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:243
+   [21] runtests(shouldrun::typeof(ReTestItems.default_shouldrun), paths::String; nworkers::Int64, nworker_threads::String, worker_init_expr::Expr, testitem_timeout::Int64, retries::Int64, debug::Int64, name::Nothing, tags::Nothing, report::Bool, logs::Symbol, verbose_results::Bool)
+      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:213
+   [22] #runtests#37
+      @ /repos/ReTestItems.jl/src/ReTestItems.jl:162 [inlined]
+   [23] top-level scope
       @ none:1
-   [38] eval
+   [24] eval
       @ ./boot.jl:368 [inlined]
-   [39] exec_options(opts::Base.JLOptions)
+   [25] exec_options(opts::Base.JLOptions)
       @ Base ./client.jl:276
-   [40] _start()
+   [26] _start()
       @ Base ./client.jl:522
+No Captured Logs for test item "testitem4" at test/testfiles/_junit_xml_test.jl:23 on worker 42127
 		</error>
 	</testcase>
-	<testcase name="testitem5" timestamp="2023-05-09T17:27:13.725" time="0.009" tests="3" skipped="2" failures="0" errors="0">
+	<testcase name="testitem5" timestamp="2023-06-21T18:19:11.908" time="0.009" tests="3" skipped="2" failures="0" errors="0">
 		<properties>
-		<property name="dd_tags[perf.bytes]" value="83454"></property>
-		<property name="dd_tags[perf.allocs]" value="1433"></property>
+		<property name="dd_tags[perf.bytes]" value="84286"></property>
+		<property name="dd_tags[perf.allocs]" value="1419"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.006706166"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.006578499"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.002469501"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.002154418"></property>
 		</properties>
 	</testcase>
-	<testcase name="testitem6" timestamp="2023-05-09T17:27:13.784" time="0.003" tests="2" skipped="1" failures="1" errors="0">
+	<testcase name="testitem6" timestamp="2023-06-21T18:19:11.918" time="0.003" tests="2" skipped="1" failures="1" errors="0">
 		<properties>
-		<property name="dd_tags[perf.bytes]" value="91886"></property>
-		<property name="dd_tags[perf.allocs]" value="1598"></property>
+		<property name="dd_tags[perf.bytes]" value="92718"></property>
+		<property name="dd_tags[perf.allocs]" value="1584"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="1.66e-7"></property>
+		<property name="dd_tags[perf.compile_time]" value="8.3e-8"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.003056542"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.002965001"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_junit_xml_test.jl:41">No Captured Logs for test item "testitem6" at test/testfiles/_junit_xml_test.jl:40 on worker 61736
-Error in testset "testitem6" on worker 61736:
+		<error message="Test failed at test/testfiles/_junit_xml_test.jl:41">Error in testset "testitem6" on worker 42127:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:41
   Expression: false
+No Captured Logs for test item "testitem6" at test/testfiles/_junit_xml_test.jl:40 on worker 42127
 		</error>
 	</testcase>
 </testsuite>

--- a/test/references/junit_xml_test_report_retries.xml
+++ b/test/references/junit_xml_test_report_retries.xml
@@ -1,198 +1,100 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites timestamp="2023-05-09T17:29:05.904" time="0.564" tests="21" skipped="4" failures="6" errors="4">
-<testsuite name="test/testfiles/_junit_xml_test.jl" timestamp="2023-05-09T17:29:05.904" time="0.564" tests="21" skipped="4" failures="6" errors="4">
-	<testcase name="testitem1" timestamp="2023-05-09T17:29:05.904" time="0.053" tests="2" skipped="0" failures="1" errors="0">
+<testsuites timestamp="2023-06-21T18:19:34.428" time="0.553" tests="21" skipped="4" failures="6" errors="4">
+<testsuite name="test/testfiles/_junit_xml_test.jl" timestamp="2023-06-21T18:19:34.428" time="0.553" tests="21" skipped="4" failures="6" errors="4">
+	<testcase name="testitem1" timestamp="2023-06-21T18:19:34.428" time="0.05" tests="2" skipped="0" failures="1" errors="0">
 		<properties>
-		<property name="dd_tags[perf.bytes]" value="4331408"></property>
-		<property name="dd_tags[perf.allocs]" value="74125"></property>
+		<property name="dd_tags[perf.bytes]" value="4851625"></property>
+		<property name="dd_tags[perf.allocs]" value="82688"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.045206915"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.042620209"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.003664210000000001"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.0033167909999999995"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_junit_xml_test.jl:4">No Captured Logs for test item "testitem1" at test/testfiles/_junit_xml_test.jl:2 on worker 63268
-Error in testset "testitem1" on worker 63268:
+		<error message="Test failed at test/testfiles/_junit_xml_test.jl:4">Error in testset "testitem1" on worker 42774:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:4
   Expression: 2 == 3
    Evaluated: 2 == 3
+No Captured Logs for test item "testitem1" at test/testfiles/_junit_xml_test.jl:2 on worker 42774
 		</error>
 	</testcase>
-	<testcase name="testitem1" timestamp="2023-05-09T17:29:06.105" time="0.002" tests="2" skipped="0" failures="1" errors="0">
+	<testcase name="testitem1" timestamp="2023-06-21T18:19:34.657" time="0.002" tests="2" skipped="0" failures="1" errors="0">
 		<properties>
-		<property name="dd_tags[perf.bytes]" value="74086"></property>
-		<property name="dd_tags[perf.allocs]" value="1257"></property>
+		<property name="dd_tags[perf.bytes]" value="74918"></property>
+		<property name="dd_tags[perf.allocs]" value="1243"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="1.66e-7"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.0"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.0023831670000000003"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.002183625"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_junit_xml_test.jl:4">No Captured Logs for test item "testitem1" at test/testfiles/_junit_xml_test.jl:2 on worker 63268
-Error in testset "testitem1" on worker 63268:
+		<error message="Test failed at test/testfiles/_junit_xml_test.jl:4">Error in testset "testitem1" on worker 42774:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:4
   Expression: 2 == 3
    Evaluated: 2 == 3
+No Captured Logs for test item "testitem1" at test/testfiles/_junit_xml_test.jl:2 on worker 42774
 		</error>
 	</testcase>
-	<testcase name="testitem2" timestamp="2023-05-09T17:29:06.157" time="0.032" tests="3" skipped="0" failures="1" errors="1">
+	<testcase name="testitem2" timestamp="2023-06-21T18:19:34.66" time="0.032" tests="3" skipped="0" failures="1" errors="1">
 		<properties>
-		<property name="dd_tags[perf.bytes]" value="3213927"></property>
-		<property name="dd_tags[perf.allocs]" value="57359"></property>
+		<property name="dd_tags[perf.bytes]" value="3214759"></property>
+		<property name="dd_tags[perf.allocs]" value="57345"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.027600499"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.028233874"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.004031583999999998"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.0038871259999999977"></property>
 		</properties>
-		<error message="Multiple errors for test item at test/testfiles/_junit_xml_test.jl:8">No Captured Logs for test item "testitem2" at test/testfiles/_junit_xml_test.jl:8 on worker 63268
-Error in testset "inner testset" on worker 63268:
+		<error message="Multiple errors for test item at test/testfiles/_junit_xml_test.jl:8">Error in testset "inner testset" on worker 42774:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:11
   Expression: 4 == 5
    Evaluated: 4 == 5
-Error in testset "inner testset" on worker 63268:
+Error in testset "inner testset" on worker 42774:
 Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:12
   Expression evaluated to non-Boolean
   Expression: not a bool
        Value: "not a bool"
+No Captured Logs for test item "testitem2" at test/testfiles/_junit_xml_test.jl:8 on worker 42774
 		</error>
 	</testcase>
-	<testcase name="testitem2" timestamp="2023-05-09T17:29:06.241" time="0.004" tests="3" skipped="0" failures="1" errors="1">
+	<testcase name="testitem2" timestamp="2023-06-21T18:19:34.745" time="0.004" tests="3" skipped="0" failures="1" errors="1">
 		<properties>
-		<property name="dd_tags[perf.bytes]" value="110342"></property>
-		<property name="dd_tags[perf.allocs]" value="1963"></property>
-		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="1.25e-7"></property>
-		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.003866208"></property>
-		</properties>
-		<error message="Multiple errors for test item at test/testfiles/_junit_xml_test.jl:8">No Captured Logs for test item "testitem2" at test/testfiles/_junit_xml_test.jl:8 on worker 63268
-Error in testset "inner testset" on worker 63268:
-Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:11
-  Expression: 4 == 5
-   Evaluated: 4 == 5
-Error in testset "inner testset" on worker 63268:
-Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:12
-  Expression evaluated to non-Boolean
-  Expression: not a bool
-       Value: "not a bool"
-		</error>
-	</testcase>
-	<testcase name="testitem3" timestamp="2023-05-09T17:29:06.293" time="0.002" tests="2" skipped="0" failures="0" errors="0">
-		<properties>
-		<property name="dd_tags[perf.bytes]" value="70286"></property>
-		<property name="dd_tags[perf.allocs]" value="1176"></property>
-		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="2.08e-7"></property>
-		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.002306376"></property>
-		</properties>
-	</testcase>
-	<testcase name="testitem4" timestamp="2023-05-09T17:29:06.343" time="0.448" tests="1" skipped="0" failures="0" errors="1">
-		<properties>
-		<property name="dd_tags[perf.bytes]" value="78751914"></property>
-		<property name="dd_tags[perf.allocs]" value="1462659"></property>
-		<property name="dd_tags[perf.gctime]" value="0.004786417"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.371259295"></property>
-		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.07191295400000003"></property>
-		</properties>
-		<error message="Error during test at test/testfiles/_junit_xml_test.jl:24">No Captured Logs for test item "testitem4" at test/testfiles/_junit_xml_test.jl:23 on worker 63268
-Error in testset "nested testset" on worker 63268:
-Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:24
-  Got exception outside of a @test
-  UndefVarError: x not defined
-  Stacktrace:
-    [1] macro expansion
-      @ /repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:25 [inlined]
-    [2] macro expansion
-      @ /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Test/src/Test.jl:1363 [inlined]
-    [3] top-level scope
-      @ /repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:25
-    [4] eval
-      @ ./boot.jl:368 [inlined]
-    [5] #81
-      @ /repos/ReTestItems.jl/src/ReTestItems.jl:701 [inlined]
-    [6] with_source_path(f::ReTestItems.var"#81#84"{Expr}, path::String)
-      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:584
-    [7] #80
-      @ /repos/ReTestItems.jl/src/ReTestItems.jl:701 [inlined]
-    [8] redirect_stdio(f::ReTestItems.var"#80#83"{TestItem, Expr}; stdin::Nothing, stderr::IOContext{IOStream}, stdout::IOContext{IOStream})
-      @ Base ./stream.jl:1411
-    [9] _redirect_logs(f::ReTestItems.var"#80#83"{TestItem, Expr}, target::IOStream)
-      @ ReTestItems /repos/ReTestItems.jl/src/log_capture.jl:111
-   [10] #27
-      @ /repos/ReTestItems.jl/src/log_capture.jl:107 [inlined]
-   [11] open(::ReTestItems.var"#27#28"{ReTestItems.var"#80#83"{TestItem, Expr}}, ::String, ::Vararg{String}; kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
-      @ Base ./io.jl:384
-   [12] open
-      @ ./io.jl:381 [inlined]
-   [13] _redirect_logs
-      @ /repos/ReTestItems.jl/src/log_capture.jl:107 [inlined]
-   [14] macro expansion
-      @ /repos/ReTestItems.jl/src/macros.jl:81 [inlined]
-   [15] runtestitem(ti::TestItem, ctx::ReTestItems.TestContext; verbose_results::Bool, finish_test::Bool, logs::Symbol)
-      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:700
-   [16] _runtests_in_current_env(shouldrun::Function, paths::Tuple{String}, projectfile::String, nworkers::Int64, nworker_threads::Int64, worker_init_expr::Expr, testitem_timeout::Int64, retries::Int64, verbose_results::Bool, debug::Int64, report::Bool, logs::Symbol)
-      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:254
-   [17] #48
-      @ /repos/ReTestItems.jl/src/ReTestItems.jl:219 [inlined]
-   [18] (::TestEnv.var"#2#3"{ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}})()
-      @ TestEnv /.julia/packages/TestEnv/bSUAo/src/activate_do.jl:19
-   [19] withenv(::TestEnv.var"#2#3"{ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, ::Pair{String, String}, ::Vararg{Pair{String}})
-      @ Base ./env.jl:172
-   [20] (::Pkg.Operations.var"#107#112"{String, Bool, Bool, Bool, TestEnv.var"#2#3"{ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, Pkg.Types.PackageSpec})()
-      @ Pkg.Operations /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:1619
-   [21] with_temp_env(fn::Pkg.Operations.var"#107#112"{String, Bool, Bool, Bool, TestEnv.var"#2#3"{ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, Pkg.Types.PackageSpec}, temp_env::String)
-      @ Pkg.Operations /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:1493
-   [22] (::Pkg.Operations.var"#105#110"{Nothing, Bool, Bool, Bool, TestEnv.var"#2#3"{ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, Pkg.Types.Context, Pkg.Types.PackageSpec, String, Pkg.Types.Project, String})(tmp::String)
-      @ Pkg.Operations /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:1582
-   [23] mktempdir(fn::Pkg.Operations.var"#105#110"{Nothing, Bool, Bool, Bool, TestEnv.var"#2#3"{ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, Pkg.Types.Context, Pkg.Types.PackageSpec, String, Pkg.Types.Project, String}, parent::String; prefix::String)
-      @ Base.Filesystem ./file.jl:764
-   [24] mktempdir(fn::Function, parent::String) (repeats 2 times)
-      @ Base.Filesystem ./file.jl:760
-   [25] sandbox(fn::Function, ctx::Pkg.Types.Context, target::Pkg.Types.PackageSpec, target_path::String, sandbox_path::String, sandbox_project_override::Pkg.Types.Project; preferences::Nothing, force_latest_compatible_version::Bool, allow_earlier_backwards_compatible_versions::Bool, allow_reresolve::Bool)
-      @ Pkg.Operations /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:1540
-   [26] sandbox
-      @ /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:1531 [inlined]
-   [27] activate(f::ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}, pkg::String)
-      @ TestEnv /.julia/packages/TestEnv/bSUAo/src/activate_do.jl:17
-   [28] activate(f::Function)
-      @ TestEnv /.julia/packages/TestEnv/bSUAo/src/activate_do.jl:13
-   [29] #47
-      @ /repos/ReTestItems.jl/src/ReTestItems.jl:218 [inlined]
-   [30] activate(f::ReTestItems.var"#47#50"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}, new_project::String)
-      @ Pkg.API /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/API.jl:1707
-   [31] (::ReTestItems.var"#46#49"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String})()
-      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:217
-   [32] with_logstate(f::Function, logstate::Any)
-      @ Base.CoreLogging ./logging.jl:511
-   [33] with_logger
-      @ ./logging.jl:623 [inlined]
-   [34] _runtests(shouldrun::Function, paths::Tuple{String}, nworkers::Int64, nworker_threads::Int64, worker_init_expr::Expr, testitem_timeout::Int64, retries::Int64, verbose_results::Bool, debug::Int64, report::Bool, logs::Symbol)
-      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:210
-   [35] runtests(shouldrun::typeof(ReTestItems.default_shouldrun), paths::String; nworkers::Int64, nworker_threads::Int64, worker_init_expr::Expr, testitem_timeout::Int64, retries::Int64, debug::Int64, name::Nothing, tags::Nothing, report::Bool, logs::Symbol, verbose_results::Bool)
-      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:190
-   [36] #runtests#37
-      @ /repos/ReTestItems.jl/src/ReTestItems.jl:140 [inlined]
-   [37] top-level scope
-      @ none:1
-   [38] eval
-      @ ./boot.jl:368 [inlined]
-   [39] exec_options(opts::Base.JLOptions)
-      @ Base ./client.jl:276
-   [40] _start()
-      @ Base ./client.jl:522
-		</error>
-	</testcase>
-	<testcase name="testitem4" timestamp="2023-05-09T17:29:06.846" time="0.007" tests="1" skipped="0" failures="0" errors="1">
-		<properties>
-		<property name="dd_tags[perf.bytes]" value="1152662"></property>
-		<property name="dd_tags[perf.allocs]" value="15078"></property>
+		<property name="dd_tags[perf.bytes]" value="111174"></property>
+		<property name="dd_tags[perf.allocs]" value="1949"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
 		<property name="dd_tags[perf.compile_time]" value="8.4e-8"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.007121791"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.003759999"></property>
 		</properties>
-		<error message="Error during test at test/testfiles/_junit_xml_test.jl:24">No Captured Logs for test item "testitem4" at test/testfiles/_junit_xml_test.jl:23 on worker 63268
-Error in testset "nested testset" on worker 63268:
+		<error message="Multiple errors for test item at test/testfiles/_junit_xml_test.jl:8">Error in testset "inner testset" on worker 42774:
+Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:11
+  Expression: 4 == 5
+   Evaluated: 4 == 5
+Error in testset "inner testset" on worker 42774:
+Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:12
+  Expression evaluated to non-Boolean
+  Expression: not a bool
+       Value: "not a bool"
+No Captured Logs for test item "testitem2" at test/testfiles/_junit_xml_test.jl:8 on worker 42774
+		</error>
+	</testcase>
+	<testcase name="testitem3" timestamp="2023-06-21T18:19:34.749" time="0.002" tests="2" skipped="0" failures="0" errors="0">
+		<properties>
+		<property name="dd_tags[perf.bytes]" value="71118"></property>
+		<property name="dd_tags[perf.allocs]" value="1162"></property>
+		<property name="dd_tags[perf.gctime]" value="0.0"></property>
+		<property name="dd_tags[perf.compile_time]" value="8.4e-8"></property>
+		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.001784791"></property>
+		</properties>
+	</testcase>
+	<testcase name="testitem4" timestamp="2023-06-21T18:19:34.751" time="0.443" tests="1" skipped="0" failures="0" errors="1">
+		<properties>
+		<property name="dd_tags[perf.bytes]" value="78309738"></property>
+		<property name="dd_tags[perf.allocs]" value="1456705"></property>
+		<property name="dd_tags[perf.gctime]" value="0.005038"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.372867168"></property>
+		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.06494529099999996"></property>
+		</properties>
+		<error message="Error during test at test/testfiles/_junit_xml_test.jl:24">Error in testset "nested testset" on worker 42774:
 Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:24
   Got exception outside of a @test
   UndefVarError: x not defined
@@ -205,118 +107,160 @@ Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml
       @ /repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:25
     [4] eval
       @ ./boot.jl:368 [inlined]
-    [5] #81
-      @ /repos/ReTestItems.jl/src/ReTestItems.jl:701 [inlined]
-    [6] with_source_path(f::ReTestItems.var"#81#84"{Expr}, path::String)
-      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:584
-    [7] #80
-      @ /repos/ReTestItems.jl/src/ReTestItems.jl:701 [inlined]
-    [8] redirect_stdio(f::ReTestItems.var"#80#83"{TestItem, Expr}; stdin::Nothing, stderr::IOContext{IOStream}, stdout::IOContext{IOStream})
+    [5] #79
+      @ /repos/ReTestItems.jl/src/ReTestItems.jl:816 [inlined]
+    [6] with_source_path(f::ReTestItems.var"#79#82"{Expr}, path::String)
+      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:688
+    [7] #78
+      @ /repos/ReTestItems.jl/src/ReTestItems.jl:816 [inlined]
+    [8] redirect_stdio(f::ReTestItems.var"#78#81"{TestItem, Expr}; stdin::Nothing, stderr::IOContext{IOStream}, stdout::IOContext{IOStream})
       @ Base ./stream.jl:1411
-    [9] _redirect_logs(f::ReTestItems.var"#80#83"{TestItem, Expr}, target::IOStream)
-      @ ReTestItems /repos/ReTestItems.jl/src/log_capture.jl:111
+    [9] _redirect_logs(f::ReTestItems.var"#78#81"{TestItem, Expr}, target::IOStream)
+      @ ReTestItems /repos/ReTestItems.jl/src/log_capture.jl:122
    [10] #27
       @ /repos/ReTestItems.jl/src/log_capture.jl:107 [inlined]
-   [11] open(::ReTestItems.var"#27#28"{ReTestItems.var"#80#83"{TestItem, Expr}}, ::String, ::Vararg{String}; kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
+   [11] open(::ReTestItems.var"#27#28"{ReTestItems.var"#78#81"{TestItem, Expr}}, ::String, ::Vararg{String}; kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
       @ Base ./io.jl:384
    [12] open
       @ ./io.jl:381 [inlined]
    [13] _redirect_logs
       @ /repos/ReTestItems.jl/src/log_capture.jl:107 [inlined]
    [14] macro expansion
-      @ /repos/ReTestItems.jl/src/macros.jl:81 [inlined]
-   [15] runtestitem(ti::TestItem, ctx::ReTestItems.TestContext; verbose_results::Bool, finish_test::Bool, logs::Symbol)
-      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:700
-   [16] _runtests_in_current_env(shouldrun::Function, paths::Tuple{String}, projectfile::String, nworkers::Int64, nworker_threads::Int64, worker_init_expr::Expr, testitem_timeout::Int64, retries::Int64, verbose_results::Bool, debug::Int64, report::Bool, logs::Symbol)
-      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:254
-   [17] #48
-      @ /repos/ReTestItems.jl/src/ReTestItems.jl:219 [inlined]
-   [18] (::TestEnv.var"#2#3"{ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}})()
-      @ TestEnv /.julia/packages/TestEnv/bSUAo/src/activate_do.jl:19
-   [19] withenv(::TestEnv.var"#2#3"{ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, ::Pair{String, String}, ::Vararg{Pair{String}})
-      @ Base ./env.jl:172
-   [20] (::Pkg.Operations.var"#107#112"{String, Bool, Bool, Bool, TestEnv.var"#2#3"{ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, Pkg.Types.PackageSpec})()
-      @ Pkg.Operations /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:1619
-   [21] with_temp_env(fn::Pkg.Operations.var"#107#112"{String, Bool, Bool, Bool, TestEnv.var"#2#3"{ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, Pkg.Types.PackageSpec}, temp_env::String)
-      @ Pkg.Operations /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:1493
-   [22] (::Pkg.Operations.var"#105#110"{Nothing, Bool, Bool, Bool, TestEnv.var"#2#3"{ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, Pkg.Types.Context, Pkg.Types.PackageSpec, String, Pkg.Types.Project, String})(tmp::String)
-      @ Pkg.Operations /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:1582
-   [23] mktempdir(fn::Pkg.Operations.var"#105#110"{Nothing, Bool, Bool, Bool, TestEnv.var"#2#3"{ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}}, Pkg.Types.Context, Pkg.Types.PackageSpec, String, Pkg.Types.Project, String}, parent::String; prefix::String)
-      @ Base.Filesystem ./file.jl:764
-   [24] mktempdir(fn::Function, parent::String) (repeats 2 times)
-      @ Base.Filesystem ./file.jl:760
-   [25] sandbox(fn::Function, ctx::Pkg.Types.Context, target::Pkg.Types.PackageSpec, target_path::String, sandbox_path::String, sandbox_project_override::Pkg.Types.Project; preferences::Nothing, force_latest_compatible_version::Bool, allow_earlier_backwards_compatible_versions::Bool, allow_reresolve::Bool)
-      @ Pkg.Operations /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:1540
-   [26] sandbox
-      @ /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/Operations.jl:1531 [inlined]
-   [27] activate(f::ReTestItems.var"#48#51"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}, pkg::String)
-      @ TestEnv /.julia/packages/TestEnv/bSUAo/src/activate_do.jl:17
-   [28] activate(f::Function)
-      @ TestEnv /.julia/packages/TestEnv/bSUAo/src/activate_do.jl:13
-   [29] #47
-      @ /repos/ReTestItems.jl/src/ReTestItems.jl:218 [inlined]
-   [30] activate(f::ReTestItems.var"#47#50"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String}, new_project::String)
-      @ Pkg.API /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Pkg/src/API.jl:1707
-   [31] (::ReTestItems.var"#46#49"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, Int64, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String})()
-      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:217
-   [32] with_logstate(f::Function, logstate::Any)
+      @ /repos/ReTestItems.jl/src/macros.jl:82 [inlined]
+   [15] runtestitem(ti::TestItem, ctx::ReTestItems.TestContext; logs::Symbol, verbose_results::Bool, finish_test::Bool)
+      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:815
+   [16] _runtests_in_current_env(shouldrun::Function, paths::Tuple{String}, projectfile::String, nworkers::Int64, nworker_threads::String, worker_init_expr::Expr, testitem_timeout::Int64, retries::Int64, verbose_results::Bool, debug::Int64, report::Bool, logs::Symbol)
+      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:296
+   [17] (::ReTestItems.var"#46#47"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, String, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String})()
+      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:260
+   [18] with_logstate(f::Function, logstate::Any)
       @ Base.CoreLogging ./logging.jl:511
-   [33] with_logger
+   [19] with_logger
       @ ./logging.jl:623 [inlined]
-   [34] _runtests(shouldrun::Function, paths::Tuple{String}, nworkers::Int64, nworker_threads::Int64, worker_init_expr::Expr, testitem_timeout::Int64, retries::Int64, verbose_results::Bool, debug::Int64, report::Bool, logs::Symbol)
-      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:210
-   [35] runtests(shouldrun::typeof(ReTestItems.default_shouldrun), paths::String; nworkers::Int64, nworker_threads::Int64, worker_init_expr::Expr, testitem_timeout::Int64, retries::Int64, debug::Int64, name::Nothing, tags::Nothing, report::Bool, logs::Symbol, verbose_results::Bool)
-      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:190
-   [36] #runtests#37
-      @ /repos/ReTestItems.jl/src/ReTestItems.jl:140 [inlined]
-   [37] top-level scope
+   [20] _runtests(shouldrun::Function, paths::Tuple{String}, nworkers::Int64, nworker_threads::String, worker_init_expr::Expr, testitem_timeout::Int64, retries::Int64, verbose_results::Bool, debug::Int64, report::Bool, logs::Symbol)
+      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:243
+   [21] runtests(shouldrun::typeof(ReTestItems.default_shouldrun), paths::String; nworkers::Int64, nworker_threads::String, worker_init_expr::Expr, testitem_timeout::Int64, retries::Int64, debug::Int64, name::Nothing, tags::Nothing, report::Bool, logs::Symbol, verbose_results::Bool)
+      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:213
+   [22] #runtests#37
+      @ /repos/ReTestItems.jl/src/ReTestItems.jl:162 [inlined]
+   [23] top-level scope
       @ none:1
-   [38] eval
+   [24] eval
       @ ./boot.jl:368 [inlined]
-   [39] exec_options(opts::Base.JLOptions)
+   [25] exec_options(opts::Base.JLOptions)
       @ Base ./client.jl:276
-   [40] _start()
+   [26] _start()
       @ Base ./client.jl:522
+No Captured Logs for test item "testitem4" at test/testfiles/_junit_xml_test.jl:23 on worker 42774
 		</error>
 	</testcase>
-	<testcase name="testitem5" timestamp="2023-05-09T17:29:06.902" time="0.009" tests="3" skipped="2" failures="0" errors="0">
+	<testcase name="testitem4" timestamp="2023-06-21T18:19:35.249" time="0.006" tests="1" skipped="0" failures="0" errors="1">
 		<properties>
-		<property name="dd_tags[perf.bytes]" value="83422"></property>
-		<property name="dd_tags[perf.allocs]" value="1432"></property>
+		<property name="dd_tags[perf.bytes]" value="706166"></property>
+		<property name="dd_tags[perf.allocs]" value="9141"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.00689604"></property>
+		<property name="dd_tags[perf.compile_time]" value="1.66e-7"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.002367877"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.005524500999999999"></property>
 		</properties>
-	</testcase>
-	<testcase name="testitem6" timestamp="2023-05-09T17:29:06.96" time="0.003" tests="2" skipped="1" failures="1" errors="0">
-		<properties>
-		<property name="dd_tags[perf.bytes]" value="91886"></property>
-		<property name="dd_tags[perf.allocs]" value="1598"></property>
-		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="1.67e-7"></property>
-		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.0030277489999999997"></property>
-		</properties>
-		<error message="Test failed at test/testfiles/_junit_xml_test.jl:41">No Captured Logs for test item "testitem6" at test/testfiles/_junit_xml_test.jl:40 on worker 63268
-Error in testset "testitem6" on worker 63268:
-Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:41
-  Expression: false
+		<error message="Error during test at test/testfiles/_junit_xml_test.jl:24">Error in testset "nested testset" on worker 42774:
+Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:24
+  Got exception outside of a @test
+  UndefVarError: x not defined
+  Stacktrace:
+    [1] macro expansion
+      @ /repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:25 [inlined]
+    [2] macro expansion
+      @ /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Test/src/Test.jl:1363 [inlined]
+    [3] top-level scope
+      @ /repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:25
+    [4] eval
+      @ ./boot.jl:368 [inlined]
+    [5] #79
+      @ /repos/ReTestItems.jl/src/ReTestItems.jl:816 [inlined]
+    [6] with_source_path(f::ReTestItems.var"#79#82"{Expr}, path::String)
+      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:688
+    [7] #78
+      @ /repos/ReTestItems.jl/src/ReTestItems.jl:816 [inlined]
+    [8] redirect_stdio(f::ReTestItems.var"#78#81"{TestItem, Expr}; stdin::Nothing, stderr::IOContext{IOStream}, stdout::IOContext{IOStream})
+      @ Base ./stream.jl:1411
+    [9] _redirect_logs(f::ReTestItems.var"#78#81"{TestItem, Expr}, target::IOStream)
+      @ ReTestItems /repos/ReTestItems.jl/src/log_capture.jl:122
+   [10] #27
+      @ /repos/ReTestItems.jl/src/log_capture.jl:107 [inlined]
+   [11] open(::ReTestItems.var"#27#28"{ReTestItems.var"#78#81"{TestItem, Expr}}, ::String, ::Vararg{String}; kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
+      @ Base ./io.jl:384
+   [12] open
+      @ ./io.jl:381 [inlined]
+   [13] _redirect_logs
+      @ /repos/ReTestItems.jl/src/log_capture.jl:107 [inlined]
+   [14] macro expansion
+      @ /repos/ReTestItems.jl/src/macros.jl:82 [inlined]
+   [15] runtestitem(ti::TestItem, ctx::ReTestItems.TestContext; logs::Symbol, verbose_results::Bool, finish_test::Bool)
+      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:815
+   [16] _runtests_in_current_env(shouldrun::Function, paths::Tuple{String}, projectfile::String, nworkers::Int64, nworker_threads::String, worker_init_expr::Expr, testitem_timeout::Int64, retries::Int64, verbose_results::Bool, debug::Int64, report::Bool, logs::Symbol)
+      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:296
+   [17] (::ReTestItems.var"#46#47"{ReTestItems.var"#shouldrun_combined#44"{Nothing, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, String, Expr, Int64, Int64, Bool, Int64, Bool, Symbol, String})()
+      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:260
+   [18] with_logstate(f::Function, logstate::Any)
+      @ Base.CoreLogging ./logging.jl:511
+   [19] with_logger
+      @ ./logging.jl:623 [inlined]
+   [20] _runtests(shouldrun::Function, paths::Tuple{String}, nworkers::Int64, nworker_threads::String, worker_init_expr::Expr, testitem_timeout::Int64, retries::Int64, verbose_results::Bool, debug::Int64, report::Bool, logs::Symbol)
+      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:243
+   [21] runtests(shouldrun::typeof(ReTestItems.default_shouldrun), paths::String; nworkers::Int64, nworker_threads::String, worker_init_expr::Expr, testitem_timeout::Int64, retries::Int64, debug::Int64, name::Nothing, tags::Nothing, report::Bool, logs::Symbol, verbose_results::Bool)
+      @ ReTestItems /repos/ReTestItems.jl/src/ReTestItems.jl:213
+   [22] #runtests#37
+      @ /repos/ReTestItems.jl/src/ReTestItems.jl:162 [inlined]
+   [23] top-level scope
+      @ none:1
+   [24] eval
+      @ ./boot.jl:368 [inlined]
+   [25] exec_options(opts::Base.JLOptions)
+      @ Base ./client.jl:276
+   [26] _start()
+      @ Base ./client.jl:522
+No Captured Logs for test item "testitem4" at test/testfiles/_junit_xml_test.jl:23 on worker 42774
 		</error>
 	</testcase>
-	<testcase name="testitem6" timestamp="2023-05-09T17:29:07.011" time="0.003" tests="2" skipped="1" failures="1" errors="0">
+	<testcase name="testitem5" timestamp="2023-06-21T18:19:35.255" time="0.009" tests="3" skipped="2" failures="0" errors="0">
 		<properties>
-		<property name="dd_tags[perf.bytes]" value="91886"></property>
-		<property name="dd_tags[perf.allocs]" value="1598"></property>
+		<property name="dd_tags[perf.bytes]" value="84254"></property>
+		<property name="dd_tags[perf.allocs]" value="1418"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="2.08e-7"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.007245707"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.0030601260000000003"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.0019372100000000008"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_junit_xml_test.jl:41">No Captured Logs for test item "testitem6" at test/testfiles/_junit_xml_test.jl:40 on worker 63268
-Error in testset "testitem6" on worker 63268:
+	</testcase>
+	<testcase name="testitem6" timestamp="2023-06-21T18:19:35.266" time="0.003" tests="2" skipped="1" failures="1" errors="0">
+		<properties>
+		<property name="dd_tags[perf.bytes]" value="92718"></property>
+		<property name="dd_tags[perf.allocs]" value="1584"></property>
+		<property name="dd_tags[perf.gctime]" value="0.0"></property>
+		<property name="dd_tags[perf.compile_time]" value="1.26e-7"></property>
+		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.002663624"></property>
+		</properties>
+		<error message="Test failed at test/testfiles/_junit_xml_test.jl:41">Error in testset "testitem6" on worker 42774:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:41
   Expression: false
+No Captured Logs for test item "testitem6" at test/testfiles/_junit_xml_test.jl:40 on worker 42774
+		</error>
+	</testcase>
+	<testcase name="testitem6" timestamp="2023-06-21T18:19:35.318" time="0.003" tests="2" skipped="1" failures="1" errors="0">
+		<properties>
+		<property name="dd_tags[perf.bytes]" value="92718"></property>
+		<property name="dd_tags[perf.allocs]" value="1584"></property>
+		<property name="dd_tags[perf.gctime]" value="0.0"></property>
+		<property name="dd_tags[perf.compile_time]" value="8.4e-8"></property>
+		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.002957833"></property>
+		</properties>
+		<error message="Test failed at test/testfiles/_junit_xml_test.jl:41">Error in testset "testitem6" on worker 42774:
+Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_junit_xml_test.jl:41
+  Expression: false
+No Captured Logs for test item "testitem6" at test/testfiles/_junit_xml_test.jl:40 on worker 42774
 		</error>
 	</testcase>
 </testsuite>

--- a/test/references/retry_tests_report_0worker.xml
+++ b/test/references/retry_tests_report_0worker.xml
@@ -1,47 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites timestamp="2023-06-21T16:43:38.289" time="40.666" tests="15" skipped="0" failures="10" errors="1">
-<testsuite name="test/testfiles/_retry_tests.jl" timestamp="2023-06-21T16:43:38.289" time="40.666" tests="15" skipped="0" failures="10" errors="1">
-	<testcase name="Pass on second run" timestamp="2023-06-21T16:43:38.289" time="0.157" tests="1" skipped="0" failures="1" errors="0">
+<testsuites timestamp="2023-06-21T18:19:54.697" time="20.598" tests="15" skipped="0" failures="10" errors="1">
+<testsuite name="test/testfiles/_retry_tests.jl" timestamp="2023-06-21T18:19:54.697" time="20.598" tests="15" skipped="0" failures="10" errors="1">
+	<testcase name="Pass on second run" timestamp="2023-06-21T18:19:54.697" time="0.103" tests="1" skipped="0" failures="1" errors="0">
 		<properties>
-		<property name="dd_tags[perf.bytes]" value="2476162"></property>
-		<property name="dd_tags[perf.allocs]" value="40391"></property>
+		<property name="dd_tags[perf.bytes]" value="2475826"></property>
+		<property name="dd_tags[perf.allocs]" value="40390"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.028837001"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.029013875"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.0029076239999999975"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.002870499999999998"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:17">Captured logs for test setup "StatefulSetup" (dependency of "Pass on second run") at test/testfiles/_retry_tests.jl:1 on worker 78453
-These are the test setup logs.
-No Captured Logs for test item "Pass on second run" at test/testfiles/_retry_tests.jl:12 on worker 78453
-Error in testset "Pass on second run" on worker 78453:
+		<error message="Test failed at test/testfiles/_retry_tests.jl:17">Error in testset "Pass on second run" on worker 43799:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:17
   Expression: x
+Captured logs for test setup "StatefulSetup" (dependency of "Pass on second run") at test/testfiles/_retry_tests.jl:1 on worker 43799
+These are the test setup logs.
+No Captured Logs for test item "Pass on second run" at test/testfiles/_retry_tests.jl:12 on worker 43799
 		</error>
 	</testcase>
-	<testcase name="Pass on second run" timestamp="2023-06-21T16:43:38.623" time="0.002" tests="1" skipped="0" failures="0" errors="0">
+	<testcase name="Pass on second run" timestamp="2023-06-21T18:19:54.978" time="0.002" tests="1" skipped="0" failures="0" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="79494"></property>
 		<property name="dd_tags[perf.allocs]" value="1227"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
 		<property name="dd_tags[perf.compile_time]" value="0.0"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.0022935"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.002274125"></property>
 		</properties>
 	</testcase>
-	<testcase name="Error, then Fail, then Pass" timestamp="2023-06-21T16:43:38.626" time="0.443" tests="1" skipped="0" failures="0" errors="1">
+	<testcase name="Error, then Fail, then Pass" timestamp="2023-06-21T18:19:54.981" time="0.433" tests="1" skipped="0" failures="0" errors="1">
 		<properties>
-		<property name="dd_tags[perf.bytes]" value="72680426"></property>
-		<property name="dd_tags[perf.allocs]" value="1352076"></property>
-		<property name="dd_tags[perf.gctime]" value="0.004835375"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.370915293"></property>
+		<property name="dd_tags[perf.bytes]" value="72681162"></property>
+		<property name="dd_tags[perf.allocs]" value="1352077"></property>
+		<property name="dd_tags[perf.gctime]" value="0.00507625"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.364509"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.06755041500000003"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.06350854099999997"></property>
 		</properties>
-		<error message="Error during test at test/testfiles/_retry_tests.jl:26">Captured logs for test setup "StatefulSetup" (dependency of "Error, then Fail, then Pass") at test/testfiles/_retry_tests.jl:1 on worker 78453
-These are the test setup logs.
-Captured Logs for test item "Error, then Fail, then Pass" at test/testfiles/_retry_tests.jl:20 on worker 78453
-These are the logs for run number: 1
-Error in testset "Error, then Fail, then Pass" on worker 78453:
+		<error message="Error during test at test/testfiles/_retry_tests.jl:26">Error in testset "Error, then Fail, then Pass" on worker 43799:
 Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:26
   Test threw exception
   Expression: not_defined_err
@@ -51,191 +47,195 @@ Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tes
      @ /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Test/src/Test.jl:464 [inlined]
    [2] top-level scope
      @ /repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:26
+Captured logs for test setup "StatefulSetup" (dependency of "Error, then Fail, then Pass") at test/testfiles/_retry_tests.jl:1 on worker 43799
+These are the test setup logs.
+Captured Logs for test item "Error, then Fail, then Pass" at test/testfiles/_retry_tests.jl:20 on worker 43799
+These are the logs for run number: 1
 		</error>
 	</testcase>
-	<testcase name="Error, then Fail, then Pass" timestamp="2023-06-21T16:43:39.129" time="0.008" tests="1" skipped="0" failures="1" errors="0">
+	<testcase name="Error, then Fail, then Pass" timestamp="2023-06-21T18:19:55.476" time="0.009" tests="1" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="216419"></property>
 		<property name="dd_tags[perf.allocs]" value="3704"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.005032125"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.005046833"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.0034412920000000003"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.003439834"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:28">Captured logs for test setup "StatefulSetup" (dependency of "Error, then Fail, then Pass") at test/testfiles/_retry_tests.jl:1 on worker 78453
-These are the test setup logs.
-Captured Logs for test item "Error, then Fail, then Pass" at test/testfiles/_retry_tests.jl:20 on worker 78453
-These are the logs for run number: 2
-Error in testset "Error, then Fail, then Pass" on worker 78453:
+		<error message="Test failed at test/testfiles/_retry_tests.jl:28">Error in testset "Error, then Fail, then Pass" on worker 43799:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:28
   Expression: 2 + 2 == 5
    Evaluated: 4 == 5
+Captured logs for test setup "StatefulSetup" (dependency of "Error, then Fail, then Pass") at test/testfiles/_retry_tests.jl:1 on worker 43799
+These are the test setup logs.
+Captured Logs for test item "Error, then Fail, then Pass" at test/testfiles/_retry_tests.jl:20 on worker 43799
+These are the logs for run number: 2
 		</error>
 	</testcase>
-	<testcase name="Error, then Fail, then Pass" timestamp="2023-06-21T16:43:39.189" time="0.003" tests="1" skipped="0" failures="0" errors="0">
+	<testcase name="Error, then Fail, then Pass" timestamp="2023-06-21T18:19:55.534" time="0.003" tests="1" skipped="0" failures="0" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="103886"></property>
 		<property name="dd_tags[perf.allocs]" value="1709"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="4.2e-8"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.0"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.003226124"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.0034195"></property>
 		</properties>
 	</testcase>
-	<testcase name="Has retries=4 and always fails" timestamp="2023-06-21T16:43:39.192" time="0.002" tests="1" skipped="0" failures="1" errors="0">
+	<testcase name="Has retries=4 and always fails" timestamp="2023-06-21T18:19:55.537" time="0.002" tests="1" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="76678"></property>
 		<property name="dd_tags[perf.allocs]" value="1171"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="1.25e-7"></property>
+		<property name="dd_tags[perf.compile_time]" value="4.1e-8"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.0022902079999999997"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.0018585009999999998"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:37">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 78453
-These are the test setup logs.
-No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:34 on worker 78453
-Error in testset "Has retries=4 and always fails" on worker 78453:
+		<error message="Test failed at test/testfiles/_retry_tests.jl:37">Error in testset "Has retries=4 and always fails" on worker 43799:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:37
   Expression: false
+Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 43799
+These are the test setup logs.
+No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:34 on worker 43799
 		</error>
 	</testcase>
-	<testcase name="Has retries=4 and always fails" timestamp="2023-06-21T16:43:39.244" time="0.002" tests="1" skipped="0" failures="1" errors="0">
+	<testcase name="Has retries=4 and always fails" timestamp="2023-06-21T18:19:55.588" time="0.002" tests="1" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="76678"></property>
 		<property name="dd_tags[perf.allocs]" value="1171"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
 		<property name="dd_tags[perf.compile_time]" value="0.0"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.002130708"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.002016083"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:37">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 78453
-These are the test setup logs.
-No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:34 on worker 78453
-Error in testset "Has retries=4 and always fails" on worker 78453:
+		<error message="Test failed at test/testfiles/_retry_tests.jl:37">Error in testset "Has retries=4 and always fails" on worker 43799:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:37
   Expression: false
+Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 43799
+These are the test setup logs.
+No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:34 on worker 43799
 		</error>
 	</testcase>
-	<testcase name="Has retries=4 and always fails" timestamp="2023-06-21T16:43:39.295" time="0.002" tests="1" skipped="0" failures="1" errors="0">
+	<testcase name="Has retries=4 and always fails" timestamp="2023-06-21T18:19:55.639" time="0.002" tests="1" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="76678"></property>
 		<property name="dd_tags[perf.allocs]" value="1171"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="4.2e-8"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.0"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.002129916"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.002069583"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:37">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 78453
-These are the test setup logs.
-No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:34 on worker 78453
-Error in testset "Has retries=4 and always fails" on worker 78453:
+		<error message="Test failed at test/testfiles/_retry_tests.jl:37">Error in testset "Has retries=4 and always fails" on worker 43799:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:37
   Expression: false
+Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 43799
+These are the test setup logs.
+No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:34 on worker 43799
 		</error>
 	</testcase>
-	<testcase name="Has retries=4 and always fails" timestamp="2023-06-21T16:43:39.347" time="0.002" tests="1" skipped="0" failures="1" errors="0">
+	<testcase name="Has retries=4 and always fails" timestamp="2023-06-21T18:19:55.688" time="0.002" tests="1" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="76678"></property>
 		<property name="dd_tags[perf.allocs]" value="1171"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
 		<property name="dd_tags[perf.compile_time]" value="1.66e-7"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.002082001"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.002014168"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:37">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 78453
-These are the test setup logs.
-No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:34 on worker 78453
-Error in testset "Has retries=4 and always fails" on worker 78453:
+		<error message="Test failed at test/testfiles/_retry_tests.jl:37">Error in testset "Has retries=4 and always fails" on worker 43799:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:37
   Expression: false
+Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 43799
+These are the test setup logs.
+No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:34 on worker 43799
 		</error>
 	</testcase>
-	<testcase name="Has retries=4 and always fails" timestamp="2023-06-21T16:43:39.398" time="0.002" tests="1" skipped="0" failures="1" errors="0">
+	<testcase name="Has retries=4 and always fails" timestamp="2023-06-21T18:19:55.738" time="0.002" tests="1" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="76678"></property>
 		<property name="dd_tags[perf.allocs]" value="1171"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="8.3e-8"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.0"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.002061083"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.001992959"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:37">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 78453
-These are the test setup logs.
-No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:34 on worker 78453
-Error in testset "Has retries=4 and always fails" on worker 78453:
+		<error message="Test failed at test/testfiles/_retry_tests.jl:37">Error in testset "Has retries=4 and always fails" on worker 43799:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:37
   Expression: false
+Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 43799
+These are the test setup logs.
+No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:34 on worker 43799
 		</error>
 	</testcase>
-	<testcase name="Has retries=1 and always fails" timestamp="2023-06-21T16:43:39.401" time="0.002" tests="1" skipped="0" failures="1" errors="0">
+	<testcase name="Has retries=1 and always fails" timestamp="2023-06-21T18:19:55.741" time="0.002" tests="1" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="76678"></property>
 		<property name="dd_tags[perf.allocs]" value="1171"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
 		<property name="dd_tags[perf.compile_time]" value="4.2e-8"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.0017605"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.002134042"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:43">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=1 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 78453
-These are the test setup logs.
-No Captured Logs for test item "Has retries=1 and always fails" at test/testfiles/_retry_tests.jl:40 on worker 78453
-Error in testset "Has retries=1 and always fails" on worker 78453:
+		<error message="Test failed at test/testfiles/_retry_tests.jl:43">Error in testset "Has retries=1 and always fails" on worker 43799:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:43
   Expression: false
+Captured logs for test setup "StatefulSetup" (dependency of "Has retries=1 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 43799
+These are the test setup logs.
+No Captured Logs for test item "Has retries=1 and always fails" at test/testfiles/_retry_tests.jl:40 on worker 43799
 		</error>
 	</testcase>
-	<testcase name="Has retries=1 and always fails" timestamp="2023-06-21T16:43:39.452" time="0.002" tests="1" skipped="0" failures="1" errors="0">
+	<testcase name="Has retries=1 and always fails" timestamp="2023-06-21T18:19:55.792" time="0.002" tests="1" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="76678"></property>
 		<property name="dd_tags[perf.allocs]" value="1171"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="8.4e-8"></property>
+		<property name="dd_tags[perf.compile_time]" value="1.25e-7"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.002114"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.0020152919999999997"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:43">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=1 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 78453
-These are the test setup logs.
-No Captured Logs for test item "Has retries=1 and always fails" at test/testfiles/_retry_tests.jl:40 on worker 78453
-Error in testset "Has retries=1 and always fails" on worker 78453:
+		<error message="Test failed at test/testfiles/_retry_tests.jl:43">Error in testset "Has retries=1 and always fails" on worker 43799:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:43
   Expression: false
+Captured logs for test setup "StatefulSetup" (dependency of "Has retries=1 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 43799
+These are the test setup logs.
+No Captured Logs for test item "Has retries=1 and always fails" at test/testfiles/_retry_tests.jl:40 on worker 43799
 		</error>
 	</testcase>
-	<testcase name="Has retries=1 and always fails" timestamp="2023-06-21T16:43:39.503" time="0.002" tests="1" skipped="0" failures="1" errors="0">
+	<testcase name="Has retries=1 and always fails" timestamp="2023-06-21T18:19:55.842" time="0.002" tests="1" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="76678"></property>
 		<property name="dd_tags[perf.allocs]" value="1171"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
 		<property name="dd_tags[perf.compile_time]" value="4.2e-8"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.002125624"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.0020821249999999998"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:43">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=1 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 78453
-These are the test setup logs.
-No Captured Logs for test item "Has retries=1 and always fails" at test/testfiles/_retry_tests.jl:40 on worker 78453
-Error in testset "Has retries=1 and always fails" on worker 78453:
+		<error message="Test failed at test/testfiles/_retry_tests.jl:43">Error in testset "Has retries=1 and always fails" on worker 43799:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:43
   Expression: false
+Captured logs for test setup "StatefulSetup" (dependency of "Has retries=1 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 43799
+These are the test setup logs.
+No Captured Logs for test item "Has retries=1 and always fails" at test/testfiles/_retry_tests.jl:40 on worker 43799
 		</error>
 	</testcase>
-	<testcase name="Timeout always" timestamp="2023-06-21T16:43:39.506" time="20.011" tests="1" skipped="0" failures="0" errors="0">
+	<testcase name="Timeout always" timestamp="2023-06-21T18:19:55.844" time="20.011" tests="1" skipped="0" failures="0" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="487732"></property>
 		<property name="dd_tags[perf.allocs]" value="8937"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.006507084"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.006296792"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="20.004509791"></property>
+		<property name="dd_tags[perf.eval_time]" value="20.00486575"></property>
 		</properties>
 	</testcase>
-	<testcase name="Timeout first, pass after" timestamp="2023-06-21T16:43:59.518" time="20.024" tests="1" skipped="0" failures="0" errors="0">
+	<testcase name="Timeout first, pass after" timestamp="2023-06-21T18:20:15.856" time="0.021" tests="1" skipped="0" failures="0" errors="0">
 		<properties>
-		<property name="dd_tags[perf.bytes]" value="3374482"></property>
-		<property name="dd_tags[perf.allocs]" value="59585"></property>
+		<property name="dd_tags[perf.bytes]" value="3375362"></property>
+		<property name="dd_tags[perf.allocs]" value="59594"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.015807416"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.016949209"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="20.008099625"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.0037824990000000017"></property>
 		</properties>
 	</testcase>
 </testsuite>

--- a/test/references/retry_tests_report_1worker.xml
+++ b/test/references/retry_tests_report_1worker.xml
@@ -1,47 +1,43 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites timestamp="2023-06-21T16:45:02.149" time="0.911" tests="18" skipped="0" failures="10" errors="5">
-<testsuite name="test/testfiles/_retry_tests.jl" timestamp="2023-06-21T16:45:02.149" time="0.911" tests="18" skipped="0" failures="10" errors="5">
-	<testcase name="Pass on second run" timestamp="2023-06-21T16:45:02.149" time="0.097" tests="1" skipped="0" failures="1" errors="0">
+<testsuites timestamp="2023-06-21T18:22:43.502" time="0.916" tests="18" skipped="0" failures="10" errors="5">
+<testsuite name="test/testfiles/_retry_tests.jl" timestamp="2023-06-21T18:22:43.502" time="0.916" tests="18" skipped="0" failures="10" errors="5">
+	<testcase name="Pass on second run" timestamp="2023-06-21T18:22:43.502" time="0.109" tests="1" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="2480386"></property>
 		<property name="dd_tags[perf.allocs]" value="40352"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.02862379"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.029507625"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.0027746679999999975"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.003933915999999999"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:17">Captured logs for test setup "StatefulSetup" (dependency of "Pass on second run") at test/testfiles/_retry_tests.jl:1 on worker 81105
-These are the test setup logs.
-No Captured Logs for test item "Pass on second run" at test/testfiles/_retry_tests.jl:12 on worker 81105
-Error in testset "Pass on second run" on worker 81105:
+		<error message="Test failed at test/testfiles/_retry_tests.jl:17">Error in testset "Pass on second run" on worker 47971:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:17
   Expression: x
+Captured logs for test setup "StatefulSetup" (dependency of "Pass on second run") at test/testfiles/_retry_tests.jl:1 on worker 47971
+These are the test setup logs.
+No Captured Logs for test item "Pass on second run" at test/testfiles/_retry_tests.jl:12 on worker 47971
 		</error>
 	</testcase>
-	<testcase name="Pass on second run" timestamp="2023-06-21T16:45:02.468" time="0.002" tests="1" skipped="0" failures="0" errors="0">
+	<testcase name="Pass on second run" timestamp="2023-06-21T18:22:43.843" time="0.002" tests="1" skipped="0" failures="0" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="79686"></property>
 		<property name="dd_tags[perf.allocs]" value="1232"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="1.67e-7"></property>
+		<property name="dd_tags[perf.compile_time]" value="8.3e-8"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.00225875"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.002265376"></property>
 		</properties>
 	</testcase>
-	<testcase name="Error, then Fail, then Pass" timestamp="2023-06-21T16:45:02.527" time="0.419" tests="1" skipped="0" failures="0" errors="1">
+	<testcase name="Error, then Fail, then Pass" timestamp="2023-06-21T18:22:43.902" time="0.414" tests="1" skipped="0" failures="0" errors="1">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="72234978"></property>
 		<property name="dd_tags[perf.allocs]" value="1344089"></property>
-		<property name="dd_tags[perf.gctime]" value="0.003617292"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.354842791"></property>
+		<property name="dd_tags[perf.gctime]" value="0.00362875"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.353205166"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.060723833000000005"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.05755654199999999"></property>
 		</properties>
-		<error message="Error during test at test/testfiles/_retry_tests.jl:26">Captured logs for test setup "StatefulSetup" (dependency of "Error, then Fail, then Pass") at test/testfiles/_retry_tests.jl:1 on worker 81105
-These are the test setup logs.
-Captured Logs for test item "Error, then Fail, then Pass" at test/testfiles/_retry_tests.jl:20 on worker 81105
-These are the logs for run number: 1
-Error in testset "Error, then Fail, then Pass" on worker 81105:
+		<error message="Error during test at test/testfiles/_retry_tests.jl:26">Error in testset "Error, then Fail, then Pass" on worker 47971:
 Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:26
   Test threw exception
   Expression: not_defined_err
@@ -51,174 +47,178 @@ Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tes
      @ /Applications/Julia-1.8.app/Contents/Resources/julia/share/julia/stdlib/v1.8/Test/src/Test.jl:464 [inlined]
    [2] top-level scope
      @ /repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:26
+Captured logs for test setup "StatefulSetup" (dependency of "Error, then Fail, then Pass") at test/testfiles/_retry_tests.jl:1 on worker 47971
+These are the test setup logs.
+Captured Logs for test item "Error, then Fail, then Pass" at test/testfiles/_retry_tests.jl:20 on worker 47971
+These are the logs for run number: 1
 		</error>
 	</testcase>
-	<testcase name="Error, then Fail, then Pass" timestamp="2023-06-21T16:45:03.015" time="0.008" tests="1" skipped="0" failures="1" errors="0">
+	<testcase name="Error, then Fail, then Pass" timestamp="2023-06-21T18:22:44.386" time="0.008" tests="1" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="217427"></property>
 		<property name="dd_tags[perf.allocs]" value="3710"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.005092666"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.005068208"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.0033679170000000007"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.003348167"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:28">Captured logs for test setup "StatefulSetup" (dependency of "Error, then Fail, then Pass") at test/testfiles/_retry_tests.jl:1 on worker 81105
-These are the test setup logs.
-Captured Logs for test item "Error, then Fail, then Pass" at test/testfiles/_retry_tests.jl:20 on worker 81105
-These are the logs for run number: 2
-Error in testset "Error, then Fail, then Pass" on worker 81105:
+		<error message="Test failed at test/testfiles/_retry_tests.jl:28">Error in testset "Error, then Fail, then Pass" on worker 47971:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:28
   Expression: 2 + 2 == 5
    Evaluated: 4 == 5
+Captured logs for test setup "StatefulSetup" (dependency of "Error, then Fail, then Pass") at test/testfiles/_retry_tests.jl:1 on worker 47971
+These are the test setup logs.
+Captured Logs for test item "Error, then Fail, then Pass" at test/testfiles/_retry_tests.jl:20 on worker 47971
+These are the logs for run number: 2
 		</error>
 	</testcase>
-	<testcase name="Error, then Fail, then Pass" timestamp="2023-06-21T16:45:03.084" time="0.004" tests="1" skipped="0" failures="0" errors="0">
+	<testcase name="Error, then Fail, then Pass" timestamp="2023-06-21T18:22:44.454" time="0.003" tests="1" skipped="0" failures="0" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="104078"></property>
 		<property name="dd_tags[perf.allocs]" value="1714"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="8.4e-8"></property>
+		<property name="dd_tags[perf.compile_time]" value="2.09e-7"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.003518082"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.0034324579999999998"></property>
 		</properties>
 	</testcase>
-	<testcase name="Has retries=4 and always fails" timestamp="2023-06-21T16:45:03.145" time="0.002" tests="1" skipped="0" failures="1" errors="0">
+	<testcase name="Has retries=4 and always fails" timestamp="2023-06-21T18:22:44.508" time="0.002" tests="1" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="76870"></property>
 		<property name="dd_tags[perf.allocs]" value="1176"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="2.5e-7"></property>
+		<property name="dd_tags[perf.compile_time]" value="1.67e-7"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.0022587500000000003"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.00205225"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:37">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 81105
-These are the test setup logs.
-No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:34 on worker 81105
-Error in testset "Has retries=4 and always fails" on worker 81105:
+		<error message="Test failed at test/testfiles/_retry_tests.jl:37">Error in testset "Has retries=4 and always fails" on worker 47971:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:37
   Expression: false
-		</error>
-	</testcase>
-	<testcase name="Has retries=4 and always fails" timestamp="2023-06-21T16:45:03.206" time="0.002" tests="1" skipped="0" failures="1" errors="0">
-		<properties>
-		<property name="dd_tags[perf.bytes]" value="76870"></property>
-		<property name="dd_tags[perf.allocs]" value="1176"></property>
-		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="8.4e-8"></property>
-		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.002122999"></property>
-		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:37">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 81105
+Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 47971
 These are the test setup logs.
-No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:34 on worker 81105
-Error in testset "Has retries=4 and always fails" on worker 81105:
-Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:37
-  Expression: false
+No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:34 on worker 47971
 		</error>
 	</testcase>
-	<testcase name="Has retries=4 and always fails" timestamp="2023-06-21T16:45:03.26" time="0.002" tests="1" skipped="0" failures="1" errors="0">
+	<testcase name="Has retries=4 and always fails" timestamp="2023-06-21T18:22:44.562" time="0.002" tests="1" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="76870"></property>
 		<property name="dd_tags[perf.allocs]" value="1176"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
 		<property name="dd_tags[perf.compile_time]" value="8.3e-8"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.002095625"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.002100625"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:37">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 81105
-These are the test setup logs.
-No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:34 on worker 81105
-Error in testset "Has retries=4 and always fails" on worker 81105:
+		<error message="Test failed at test/testfiles/_retry_tests.jl:37">Error in testset "Has retries=4 and always fails" on worker 47971:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:37
   Expression: false
+Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 47971
+These are the test setup logs.
+No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:34 on worker 47971
 		</error>
 	</testcase>
-	<testcase name="Has retries=4 and always fails" timestamp="2023-06-21T16:45:03.314" time="0.002" tests="1" skipped="0" failures="1" errors="0">
+	<testcase name="Has retries=4 and always fails" timestamp="2023-06-21T18:22:44.618" time="0.002" tests="1" skipped="0" failures="1" errors="0">
+		<properties>
+		<property name="dd_tags[perf.bytes]" value="76870"></property>
+		<property name="dd_tags[perf.allocs]" value="1176"></property>
+		<property name="dd_tags[perf.gctime]" value="0.0"></property>
+		<property name="dd_tags[perf.compile_time]" value="2.08e-7"></property>
+		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.0021199170000000002"></property>
+		</properties>
+		<error message="Test failed at test/testfiles/_retry_tests.jl:37">Error in testset "Has retries=4 and always fails" on worker 47971:
+Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:37
+  Expression: false
+Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 47971
+These are the test setup logs.
+No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:34 on worker 47971
+		</error>
+	</testcase>
+	<testcase name="Has retries=4 and always fails" timestamp="2023-06-21T18:22:44.673" time="0.002" tests="1" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="76870"></property>
 		<property name="dd_tags[perf.allocs]" value="1176"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
 		<property name="dd_tags[perf.compile_time]" value="1.66e-7"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.0021430840000000004"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.002009584"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:37">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 81105
-These are the test setup logs.
-No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:34 on worker 81105
-Error in testset "Has retries=4 and always fails" on worker 81105:
+		<error message="Test failed at test/testfiles/_retry_tests.jl:37">Error in testset "Has retries=4 and always fails" on worker 47971:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:37
   Expression: false
-		</error>
-	</testcase>
-	<testcase name="Has retries=4 and always fails" timestamp="2023-06-21T16:45:03.369" time="0.002" tests="1" skipped="0" failures="1" errors="0">
-		<properties>
-		<property name="dd_tags[perf.bytes]" value="76870"></property>
-		<property name="dd_tags[perf.allocs]" value="1176"></property>
-		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="4.1e-8"></property>
-		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.002065292"></property>
-		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:37">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 81105
+Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 47971
 These are the test setup logs.
-No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:34 on worker 81105
-Error in testset "Has retries=4 and always fails" on worker 81105:
-Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:37
-  Expression: false
+No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:34 on worker 47971
 		</error>
 	</testcase>
-	<testcase name="Has retries=1 and always fails" timestamp="2023-06-21T16:45:03.42" time="0.002" tests="1" skipped="0" failures="1" errors="0">
-		<properties>
-		<property name="dd_tags[perf.bytes]" value="76870"></property>
-		<property name="dd_tags[perf.allocs]" value="1176"></property>
-		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="4.2e-8"></property>
-		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.002043875"></property>
-		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:43">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=1 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 81105
-These are the test setup logs.
-No Captured Logs for test item "Has retries=1 and always fails" at test/testfiles/_retry_tests.jl:40 on worker 81105
-Error in testset "Has retries=1 and always fails" on worker 81105:
-Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:43
-  Expression: false
-		</error>
-	</testcase>
-	<testcase name="Has retries=1 and always fails" timestamp="2023-06-21T16:45:03.472" time="0.002" tests="1" skipped="0" failures="1" errors="0">
+	<testcase name="Has retries=4 and always fails" timestamp="2023-06-21T18:22:44.73" time="0.002" tests="1" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="76870"></property>
 		<property name="dd_tags[perf.allocs]" value="1176"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
 		<property name="dd_tags[perf.compile_time]" value="8.4e-8"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.002056583"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.002091374"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:43">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=1 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 81105
-These are the test setup logs.
-No Captured Logs for test item "Has retries=1 and always fails" at test/testfiles/_retry_tests.jl:40 on worker 81105
-Error in testset "Has retries=1 and always fails" on worker 81105:
-Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:43
+		<error message="Test failed at test/testfiles/_retry_tests.jl:37">Error in testset "Has retries=4 and always fails" on worker 47971:
+Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:37
   Expression: false
+Captured logs for test setup "StatefulSetup" (dependency of "Has retries=4 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 47971
+These are the test setup logs.
+No Captured Logs for test item "Has retries=4 and always fails" at test/testfiles/_retry_tests.jl:34 on worker 47971
 		</error>
 	</testcase>
-	<testcase name="Has retries=1 and always fails" timestamp="2023-06-21T16:45:03.526" time="0.002" tests="1" skipped="0" failures="1" errors="0">
+	<testcase name="Has retries=1 and always fails" timestamp="2023-06-21T18:22:44.782" time="0.002" tests="1" skipped="0" failures="1" errors="0">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="76870"></property>
 		<property name="dd_tags[perf.allocs]" value="1176"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="4.2e-8"></property>
+		<property name="dd_tags[perf.compile_time]" value="1.67e-7"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.002347583"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.0020149169999999997"></property>
 		</properties>
-		<error message="Test failed at test/testfiles/_retry_tests.jl:43">Captured logs for test setup "StatefulSetup" (dependency of "Has retries=1 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 81105
-These are the test setup logs.
-No Captured Logs for test item "Has retries=1 and always fails" at test/testfiles/_retry_tests.jl:40 on worker 81105
-Error in testset "Has retries=1 and always fails" on worker 81105:
+		<error message="Test failed at test/testfiles/_retry_tests.jl:43">Error in testset "Has retries=1 and always fails" on worker 47971:
 Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:43
   Expression: false
+Captured logs for test setup "StatefulSetup" (dependency of "Has retries=1 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 47971
+These are the test setup logs.
+No Captured Logs for test item "Has retries=1 and always fails" at test/testfiles/_retry_tests.jl:40 on worker 47971
 		</error>
 	</testcase>
-	<testcase name="Timeout always" timestamp="2023-06-21T16:45:08.784" time="0.303" tests="1" skipped="0" failures="0" errors="1">
+	<testcase name="Has retries=1 and always fails" timestamp="2023-06-21T18:22:44.834" time="0.002" tests="1" skipped="0" failures="1" errors="0">
+		<properties>
+		<property name="dd_tags[perf.bytes]" value="76870"></property>
+		<property name="dd_tags[perf.allocs]" value="1176"></property>
+		<property name="dd_tags[perf.gctime]" value="0.0"></property>
+		<property name="dd_tags[perf.compile_time]" value="4.1e-8"></property>
+		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.002045293"></property>
+		</properties>
+		<error message="Test failed at test/testfiles/_retry_tests.jl:43">Error in testset "Has retries=1 and always fails" on worker 47971:
+Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:43
+  Expression: false
+Captured logs for test setup "StatefulSetup" (dependency of "Has retries=1 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 47971
+These are the test setup logs.
+No Captured Logs for test item "Has retries=1 and always fails" at test/testfiles/_retry_tests.jl:40 on worker 47971
+		</error>
+	</testcase>
+	<testcase name="Has retries=1 and always fails" timestamp="2023-06-21T18:22:44.888" time="0.002" tests="1" skipped="0" failures="1" errors="0">
+		<properties>
+		<property name="dd_tags[perf.bytes]" value="76870"></property>
+		<property name="dd_tags[perf.allocs]" value="1176"></property>
+		<property name="dd_tags[perf.gctime]" value="0.0"></property>
+		<property name="dd_tags[perf.compile_time]" value="4.1e-8"></property>
+		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.002284084"></property>
+		</properties>
+		<error message="Test failed at test/testfiles/_retry_tests.jl:43">Error in testset "Has retries=1 and always fails" on worker 47971:
+Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:43
+  Expression: false
+Captured logs for test setup "StatefulSetup" (dependency of "Has retries=1 and always fails") at test/testfiles/_retry_tests.jl:1 on worker 47971
+These are the test setup logs.
+No Captured Logs for test item "Has retries=1 and always fails" at test/testfiles/_retry_tests.jl:40 on worker 47971
+		</error>
+	</testcase>
+	<testcase name="Timeout always" timestamp="2023-06-21T18:22:50.159" time="0.3" tests="1" skipped="0" failures="0" errors="1">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="0"></property>
 		<property name="dd_tags[perf.allocs]" value="0"></property>
@@ -227,22 +227,22 @@ Test Failed at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
 		<property name="dd_tags[perf.eval_time]" value="0.0"></property>
 		</properties>
-		<error message="Error during test at test/testfiles/_retry_tests.jl:54">Captured Logs for test item "Timeout always" at test/testfiles/_retry_tests.jl:54 on worker 81822
-
-signal (15): Terminated: 15
-in expression starting at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:60
-__psynch_cvwait at /usr/lib/system/libsystem_kernel.dylib (unknown line)
-unknown function (ip: 0x0)
-kevent at /usr/lib/system/libsystem_kernel.dylib (unknown line)
-unknown function (ip: 0x0)
-Allocations: 5231398 (Pool: 5229065; Big: 2333); GC: 30
-Error in testset "Timeout always" on worker 81822:
+		<error message="Error during test at test/testfiles/_retry_tests.jl:54">Error in testset "Timeout always" on worker 48597:
 Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:54
   Got exception outside of a @test
   Timed out after 5s evaluating test item "Timeout always" (run=1)
+Captured Logs for test item "Timeout always" at test/testfiles/_retry_tests.jl:54 on worker 48597
+
+signal (15): Terminated: 15
+in expression starting at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:60
+__psynch_cvwait at /usr/lib/system/libsystem_kernel.dylib (unknown line)
+unknown function (ip: 0x0)
+kevent at /usr/lib/system/libsystem_kernel.dylib (unknown line)
+unknown function (ip: 0x0)
+Allocations: 5231242 (Pool: 5228911; Big: 2331); GC: 30
 		</error>
 	</testcase>
-	<testcase name="Timeout always" timestamp="2023-06-21T16:45:14.846" time="0.0" tests="1" skipped="0" failures="0" errors="1">
+	<testcase name="Timeout always" timestamp="2023-06-21T18:22:56.246" time="0.0" tests="1" skipped="0" failures="0" errors="1">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="0"></property>
 		<property name="dd_tags[perf.allocs]" value="0"></property>
@@ -251,31 +251,11 @@ Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tes
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
 		<property name="dd_tags[perf.eval_time]" value="0.0"></property>
 		</properties>
-		<error message="Error during test at test/testfiles/_retry_tests.jl:54">Captured Logs for test item "Timeout always" at test/testfiles/_retry_tests.jl:54 on worker 81822
-
-signal (15): Terminated: 15
-in expression starting at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:60
-__psynch_cvwait at /usr/lib/system/libsystem_kernel.dylib (unknown line)
-unknown function (ip: 0x0)
-kevent at /usr/lib/system/libsystem_kernel.dylib (unknown line)
-unknown function (ip: 0x0)
-Allocations: 3068722 (Pool: 3067612; Big: 1110); GC: 3
-Error in testset "Timeout always" on worker 81822:
+		<error message="Error during test at test/testfiles/_retry_tests.jl:54">Error in testset "Timeout always" on worker 48597:
 Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:54
   Got exception outside of a @test
   Timed out after 5s evaluating test item "Timeout always" (run=2)
-		</error>
-	</testcase>
-	<testcase name="Timeout always" timestamp="2023-06-21T16:45:20.618" time="0.0" tests="1" skipped="0" failures="0" errors="1">
-		<properties>
-		<property name="dd_tags[perf.bytes]" value="0"></property>
-		<property name="dd_tags[perf.allocs]" value="0"></property>
-		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.0"></property>
-		</properties>
-		<error message="Error during test at test/testfiles/_retry_tests.jl:54">Captured Logs for test item "Timeout always" at test/testfiles/_retry_tests.jl:54 on worker 81822
+Captured Logs for test item "Timeout always" at test/testfiles/_retry_tests.jl:54 on worker 48597
 
 signal (15): Terminated: 15
 in expression starting at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:60
@@ -283,14 +263,10 @@ __psynch_cvwait at /usr/lib/system/libsystem_kernel.dylib (unknown line)
 unknown function (ip: 0x0)
 kevent at /usr/lib/system/libsystem_kernel.dylib (unknown line)
 unknown function (ip: 0x0)
-Allocations: 3068695 (Pool: 3067583; Big: 1112); GC: 3
-Error in testset "Timeout always" on worker 81822:
-Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:54
-  Got exception outside of a @test
-  Timed out after 5s evaluating test item "Timeout always" (run=3)
+Allocations: 3068667 (Pool: 3067557; Big: 1110); GC: 3
 		</error>
 	</testcase>
-	<testcase name="Timeout first, pass after" timestamp="2023-06-21T16:45:26.413" time="0.0" tests="1" skipped="0" failures="0" errors="1">
+	<testcase name="Timeout always" timestamp="2023-06-21T18:23:02.022" time="0.0" tests="1" skipped="0" failures="0" errors="1">
 		<properties>
 		<property name="dd_tags[perf.bytes]" value="0"></property>
 		<property name="dd_tags[perf.allocs]" value="0"></property>
@@ -299,7 +275,35 @@ Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tes
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
 		<property name="dd_tags[perf.eval_time]" value="0.0"></property>
 		</properties>
-		<error message="Error during test at test/testfiles/_retry_tests.jl:64">Captured Logs for test item "Timeout first, pass after" at test/testfiles/_retry_tests.jl:64 on worker 81835
+		<error message="Error during test at test/testfiles/_retry_tests.jl:54">Error in testset "Timeout always" on worker 48597:
+Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:54
+  Got exception outside of a @test
+  Timed out after 5s evaluating test item "Timeout always" (run=3)
+Captured Logs for test item "Timeout always" at test/testfiles/_retry_tests.jl:54 on worker 48597
+
+signal (15): Terminated: 15
+in expression starting at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:60
+__psynch_cvwait at /usr/lib/system/libsystem_kernel.dylib (unknown line)
+unknown function (ip: 0x0)
+kevent at /usr/lib/system/libsystem_kernel.dylib (unknown line)
+unknown function (ip: 0x0)
+Allocations: 3068817 (Pool: 3067707; Big: 1110); GC: 3
+		</error>
+	</testcase>
+	<testcase name="Timeout first, pass after" timestamp="2023-06-21T18:23:07.785" time="0.0" tests="1" skipped="0" failures="0" errors="1">
+		<properties>
+		<property name="dd_tags[perf.bytes]" value="0"></property>
+		<property name="dd_tags[perf.allocs]" value="0"></property>
+		<property name="dd_tags[perf.gctime]" value="0.0"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.0"></property>
+		</properties>
+		<error message="Error during test at test/testfiles/_retry_tests.jl:64">Error in testset "Timeout first, pass after" on worker 49020:
+Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:64
+  Got exception outside of a @test
+  Timed out after 5s evaluating test item "Timeout first, pass after" (run=1)
+Captured Logs for test item "Timeout first, pass after" at test/testfiles/_retry_tests.jl:64 on worker 49020
 
 signal (15): Terminated: 15
 in expression starting at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:71
@@ -307,21 +311,17 @@ __psynch_cvwait at /usr/lib/system/libsystem_kernel.dylib (unknown line)
 unknown function (ip: 0x0)
 kevent at /usr/lib/system/libsystem_kernel.dylib (unknown line)
 unknown function (ip: 0x0)
-Allocations: 3061005 (Pool: 3059893; Big: 1112); GC: 3
-Error in testset "Timeout first, pass after" on worker 81835:
-Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:64
-  Got exception outside of a @test
-  Timed out after 5s evaluating test item "Timeout first, pass after" (run=1)
+Allocations: 3061081 (Pool: 3059972; Big: 1109); GC: 3
 		</error>
 	</testcase>
-	<testcase name="Timeout first, pass after" timestamp="2023-06-21T16:45:27.43" time="0.06" tests="1" skipped="0" failures="0" errors="0">
+	<testcase name="Timeout first, pass after" timestamp="2023-06-21T18:23:08.801" time="0.06" tests="1" skipped="0" failures="0" errors="0">
 		<properties>
-		<property name="dd_tags[perf.bytes]" value="8002087"></property>
-		<property name="dd_tags[perf.allocs]" value="136513"></property>
+		<property name="dd_tags[perf.bytes]" value="8002663"></property>
+		<property name="dd_tags[perf.allocs]" value="136514"></property>
 		<property name="dd_tags[perf.gctime]" value="0.0"></property>
-		<property name="dd_tags[perf.compile_time]" value="0.052138169"></property>
+		<property name="dd_tags[perf.compile_time]" value="0.0521865"></property>
 		<property name="dd_tags[perf.recompile_time]" value="0.0"></property>
-		<property name="dd_tags[perf.eval_time]" value="0.003812705999999999"></property>
+		<property name="dd_tags[perf.eval_time]" value="0.0037945410000000054"></property>
 		</properties>
 	</testcase>
 </testsuite>


### PR DESCRIPTION
for anywhere that truncates the output (such as DataDog), we need to make sure the most important info is high up

fix https://relationalai.atlassian.net/jira/software/c/projects/RAI/issues/RAI-13805