### PR TITLE
Change test report to aggregate results by default

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReTestItems"
 uuid = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
-version = "1.11.0"
+version = "1.12.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -137,8 +137,8 @@ will be run.
   - `:issues`: Logs are saved to a file and only printed if there were any errors or failures.
   For interative sessions, `:eager` is the default when running with 0 or 1 workers, `:batched` otherwise.
   For non-interactive sessions, `:issues` is used by default.
-- `verbose_results::Bool`: If `true`, the final test report will test each `@testset`, otherwise
-    the results are aggregated on the `@testitem` level. Default is `false` for non-interactive sessions
+- `verbose_results::Bool`: If `true`, the final test report will list each `@testitem`, otherwise
+    the results are aggregated on the file level. Default is `false` for non-interactive sessions
     or when `logs=:issues`, `true` otherwise.
 """
 function runtests end
@@ -274,7 +274,7 @@ function _runtests_in_current_env(
     @info "Scanning for test items in project `$proj_name` at paths: $(join(paths, ", "))"
     inc_time = time()
     @debugv 1 "Including tests in $paths"
-    testitems, _ = include_testfiles!(proj_name, projectfile, paths, shouldrun, report)
+    testitems, _ = include_testfiles!(proj_name, projectfile, paths, shouldrun, verbose_results, report)
     ntestitems = length(testitems.testitems)
     @debugv 1 "Done including tests in $paths"
     @info "Finished scanning for test items in $(round(time() - inc_time, digits=2)) seconds." *
@@ -556,7 +556,7 @@ function _throw_not_macrocall(expr)
 end
 
 # for each directory, kick off a recursive test-finding task
-function include_testfiles!(project_name, projectfile, paths, shouldrun, report::Bool)
+function include_testfiles!(project_name, projectfile, paths, shouldrun, verbose_results::Bool, report::Bool)
     project_root = dirname(projectfile)
     subproject_root = nothing  # don't recurse into directories with their own Project.toml.
     root_node = DirNode(project_name; report, verbose=true)
@@ -602,7 +602,7 @@ function include_testfiles!(project_name, projectfile, paths, shouldrun, report:
                 continue
             end
             fpath = relpath(filepath, project_root)
-            file_node = FileNode(fpath, shouldrun; report, verbose=true)
+            file_node = FileNode(fpath, shouldrun; report, verbose=verbose_results)
             testitem_names = Set{String}() # to enforce that names in the same file are unique
             push!(dir_node, file_node)
             @debugv 1 "Including test items from file `$filepath`"

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -138,7 +138,7 @@ will be run.
   For interative sessions, `:eager` is the default when running with 0 or 1 workers, `:batched` otherwise.
   For non-interactive sessions, `:issues` is used by default.
 - `verbose_results::Bool`: If `true`, the final test report will list each `@testitem`, otherwise
-    the results are aggregated on the file level. Default is `false` for non-interactive sessions
+    the results are aggregated. Default is `false` for non-interactive sessions
     or when `logs=:issues`, `true` otherwise.
 """
 function runtests end
@@ -559,7 +559,7 @@ end
 function include_testfiles!(project_name, projectfile, paths, shouldrun, verbose_results::Bool, report::Bool)
     project_root = dirname(projectfile)
     subproject_root = nothing  # don't recurse into directories with their own Project.toml.
-    root_node = DirNode(project_name; report, verbose=true)
+    root_node = DirNode(project_name; report, verbose=verbose_results)
     dir_nodes = Dict{String, DirNode}()
     # setup_channel is populated in store_test_setup when we expand a @testsetup
     # we set it below in tls as __RE_TEST_SETUPS__ for each included file
@@ -585,7 +585,7 @@ function include_testfiles!(project_name, projectfile, paths, shouldrun, verbose
         end
         rpath = relpath(root, project_root)
         startswith(rpath, hidden_re) && continue # skip hidden directories
-        dir_node = DirNode(rpath; report, verbose=true)
+        dir_node = DirNode(rpath; report, verbose=verbose_results)
         dir_nodes[rpath] = dir_node
         push!(get(dir_nodes, dirname(rpath), root_node), dir_node)
         for file in files

--- a/test/integrationtests.jl
+++ b/test/integrationtests.jl
@@ -315,27 +315,6 @@ end
     end
     c = IOCapture.capture() do
         Test.print_test_results(testset)
-        ## Should look like (possibly with different Time values):
-        # Test Summary:                     | Pass  Total  Time
-        # TestsInSrc                        |   13     13  0.0s
-        #   src                             |   13     13
-        #     src/a_dir                     |    6      6
-        #       src/a_dir/a1_test.jl        |    1      1
-        #         a1                        |    1      1  0.0s
-        #       src/a_dir/a2_test.jl        |    2      2
-        #         a2                        |    2      2  0.0s
-        #       src/a_dir/x_dir             |    3      3
-        #         src/a_dir/x_dir/x_test.jl |    3      3
-        #           x                       |    1      1  0.0s
-        #           y                       |    1      1  0.0s
-        #           z                       |    1      1  0.0s
-        #     src/b_dir                     |    1      1
-        #       src/b_dir/b_test.jl         |    1      1
-        #         b                         |    1      1  0.0s
-        #     src/bar_tests.jl              |    4      4
-        #       bar                         |    4      4  0.0s
-        #     src/foo_test.jl               |    2      2
-        #       foo                         |    2      2  0.0s
     end
     # Test with `contains` rather than `match` so failure print an informative message.
     @test contains(
@@ -349,6 +328,7 @@ end
                 a1                        \|    1      1  \s*\d*.\ds
               src/a_dir/a2_test.jl        \|    2      2  \s*
                 a2                        \|    2      2  \s*\d*.\ds
+                  a2_testset              \|    1      1  \s*\d*.\ds
               src/a_dir/x_dir             \|    3      3  \s*
                 src/a_dir/x_dir/x_test.jl \|    3      3  \s*
                   z                       \|    1      1  \s*\d*.\ds
@@ -359,6 +339,7 @@ end
                 b                         \|    1      1  \s*\d*.\ds
             src/bar_tests.jl              \|    4      4  \s*
               bar                         \|    4      4  \s*\d*.\ds
+                bar values                \|    2      2  \s*\d*.\ds
             src/foo_test.jl               \|    2      2  \s*
               foo                         \|    2      2  \s*\d*.\ds
         """
@@ -392,8 +373,10 @@ end
                 Test.print_test_results(testset)
             end
             if verbose_results
+                @test contains(c2.output, "NoDeps-testitem")
                 @test contains(c2.output, "inner-testset")
             else
+                @test !contains(c2.output, "NoDeps-testitem")
                 @test !contains(c2.output, "inner-testset")
             end
         finally

--- a/test/integrationtests.jl
+++ b/test/integrationtests.jl
@@ -310,6 +310,7 @@ end
 @testset "print report sorted" begin
     # Test that the final summary has testitems by file, with files sorted alphabetically
     using IOCapture
+    # verbose_results=true
     testset = with_test_package("TestsInSrc.jl") do
         runtests(verbose_results=true)
     end
@@ -344,6 +345,21 @@ end
               foo                         \|    2      2  \s*\d*.\ds
         """
     )
+    # verbose_results=false
+    testset = with_test_package("TestsInSrc.jl") do
+        runtests(verbose_results=false)
+    end
+    c = IOCapture.capture() do
+        Test.print_test_results(testset)
+    end
+    m = match(
+        r"""
+        Test Summary: \| Pass  Total  Time
+        TestsInSrc    \|   13     13  \s*\d*.\ds
+        """,
+        c.output
+    )
+    @test m.match == c.output
 end
 
 @testset "`verbose_results`, `debug` and `logs` keywords" begin

--- a/test/integrationtests.jl
+++ b/test/integrationtests.jl
@@ -311,7 +311,7 @@ end
     # Test that the final summary has testitems by file, with files sorted alphabetically
     using IOCapture
     testset = with_test_package("TestsInSrc.jl") do
-        runtests()
+        runtests(verbose_results=true)
     end
     c = IOCapture.capture() do
         Test.print_test_results(testset)

--- a/test/internals.jl
+++ b/test/internals.jl
@@ -90,18 +90,19 @@ end
 @testset "only requested testfiles included" begin
     using ReTestItems: ReTestItems, include_testfiles!, identify_project, is_test_file
     shouldrun = Returns(true)
+    verbose_results = false
     report = false
 
     # Requesting only non-existent files/dirs should result in no files being included
-    ti, setups = include_testfiles!("proj", "/this/file/", ("/this/file/is/not/a/t-e-s-tfile.jl",), shouldrun, report)
+    ti, setups = include_testfiles!("proj", "/this/file/", ("/this/file/is/not/a/t-e-s-tfile.jl",), shouldrun, verbose_results, report)
     @test isempty(ti.testitems)
     @test isempty(setups)
 
-    ti, setups = include_testfiles!("proj", "/this/file/", ("/this/file/does/not/exist/imaginary_tests.jl",), shouldrun, report)
+    ti, setups = include_testfiles!("proj", "/this/file/", ("/this/file/does/not/exist/imaginary_tests.jl",), shouldrun, verbose_results, report)
     @test isempty(ti.testitems)
     @test isempty(setups)
 
-    ti, setups = include_testfiles!("proj", "/this/dir/", ("/this/dir/does/not/exist/", "/this/dir/also/not/exist/"), shouldrun, report)
+    ti, setups = include_testfiles!("proj", "/this/dir/", ("/this/dir/does/not/exist/", "/this/dir/also/not/exist/"), shouldrun, verbose_results, report)
     @test isempty(ti.testitems)
     @test isempty(setups)
 
@@ -109,7 +110,7 @@ end
     pkg_file = joinpath(pkgdir(ReTestItems), "test", "packages", "NoDeps.jl", "src", "NoDeps.jl")
     @assert isfile(pkg_file)
     project = identify_project(pkg_file)
-    ti, setups = include_testfiles!("NoDeps.jl", project, (pkg_file,), shouldrun, report)
+    ti, setups = include_testfiles!("NoDeps.jl", project, (pkg_file,), shouldrun, verbose_results, report)
     @test isempty(ti.testitems)
     @test isempty(setups)
 
@@ -117,7 +118,7 @@ end
     pkg_src = joinpath(pkgdir(ReTestItems), "test", "packages", "NoDeps.jl", "src")
     @assert all(!is_test_file, readdir(pkg_src))
     project = identify_project(pkg_src)
-    ti, setups = include_testfiles!("NoDeps.jl", project, (pkg_src,), shouldrun, report)
+    ti, setups = include_testfiles!("NoDeps.jl", project, (pkg_src,), shouldrun, verbose_results, report)
     @test isempty(ti.testitems)
     @test isempty(setups)
 
@@ -125,7 +126,7 @@ end
     pkg_file = joinpath(pkgdir(ReTestItems), "test", "packages", "TestsInSrc.jl", "src", "foo_test.jl")
     @assert isfile(pkg_file) && is_test_file(pkg_file)
     project = identify_project(pkg_file)
-    ti, setups = include_testfiles!("TestsInSrc.jl", project, (pkg_file,), shouldrun, report)
+    ti, setups = include_testfiles!("TestsInSrc.jl", project, (pkg_file,), shouldrun, verbose_results, report)
     @test length(ti.testitems) == 1
     @test isempty(setups)
 
@@ -133,7 +134,7 @@ end
     pkg = joinpath(pkgdir(ReTestItems), "test", "packages", "TestsInSrc.jl")
     @assert any(!is_test_file, readdir(joinpath(pkg, "src")))
     project = identify_project(pkg)
-    ti, setups = include_testfiles!("TestsInSrc.jl", project, (pkg,), shouldrun, report)
+    ti, setups = include_testfiles!("TestsInSrc.jl", project, (pkg,), shouldrun, verbose_results, report)
     @test map(x -> x.name, ti.testitems) == ["a1", "a2", "z", "y", "x", "b", "bar", "foo"]
     @test isempty(setups)
 end
@@ -141,6 +142,7 @@ end
 @testset "testsetup files always included" begin
     using ReTestItems: include_testfiles!, is_test_file, is_testsetup_file
     shouldrun = Returns(true)
+    verbose_results = false
     report = false
     proj = joinpath(pkgdir(ReTestItems), "Project.toml")
 
@@ -148,7 +150,7 @@ end
     @assert count(is_testsetup_file, readdir(test_dir)) == 1
     file = joinpath(test_dir, "_empty_file.jl")
     @assert isfile(file) && !is_test_file(file)
-    ti, setups = include_testfiles!("empty_file", proj, (file,), shouldrun, report)
+    ti, setups = include_testfiles!("empty_file", proj, (file,), shouldrun, verbose_results, report)
     @test length(ti.testitems) == 0 # just the testsetup
     @test haskey(setups, :FooSetup)
 
@@ -157,7 +159,7 @@ end
     @assert !any(is_testsetup_file, readdir(nested_dir))
     file = joinpath(nested_dir, "_testitem_test.jl")
     @assert isfile(file)
-    ti, setups = include_testfiles!("_nested", proj, (file,), shouldrun, report)
+    ti, setups = include_testfiles!("_nested", proj, (file,), shouldrun, verbose_results, report)
     @test length(ti.testitems) == 1 # the testsetup and only one test item
     @test haskey(setups, :FooSetup)
 end

--- a/test/packages/NoDeps.jl/test/NoDeps_tests.jl
+++ b/test/packages/NoDeps.jl/test/NoDeps_tests.jl
@@ -1,4 +1,4 @@
-@testitem "NoDeps" begin
+@testitem "NoDeps-testitem" begin
     @testset "inner-testset" begin
         @test answer() == 42
     end


### PR DESCRIPTION
Previously we were always showing all test items in the report printed at the end of the tests.

We chose this because `@testitem`s are the "units" that get run, so we thought it was helpful to always see which test items were run. But, this scales poorly. Once you have hundreds (or even thousands) or `@testitem`s, this makes the report too verbose. In particular, if you've 1/1000 test items fail, it can be difficult to scan the report to see which one it is that failed.

Now, with this PR, we default to aggregating results, with the `verbose_results` keyword used for opting-in to a fully-expanded report. 

As ever, test failures will be fully expanded in the report to show the test item that failed. 

The default for interactive sessions (at the REPL) is still `verbose_results=true`, which has the same output as before.

### Examples

Before, if all tests passed:
```julia
Test Summary:                     | Pass  Total  Time
TestsInSrc                        |   13     13  0.1s
  src                             |   13     13
    src/a_dir                     |    6      6
      src/a_dir/a1_test.jl        |    1      1
        a1                        |    1      1  0.0s
      src/a_dir/a2_test.jl        |    2      2
        a2                        |    2      2  0.0s
      src/a_dir/x_dir             |    3      3
        src/a_dir/x_dir/x_test.jl |    3      3
          z                       |    1      1  0.0s
          y                       |    1      1  0.0s
          x                       |    1      1  0.0s
    src/b_dir                     |    1      1
      src/b_dir/b_test.jl         |    1      1
        b                         |    1      1  0.0s
    src/bar_tests.jl              |    4      4
      bar                         |    4      4  0.0s
    src/foo_test.jl               |    2      2
      foo                         |    2      2  0.0s
```

Now, if all tests passed:
```julia
Test Summary: | Pass  Total  Time
TestsInSrc    |   13     13  0.1s
```

Before, if a test failed:
```julia
Test Summary:                     | Pass  Fail  Total  Time
TestsInSrc                        |   12     1     13  0.0s
  src                             |   12     1     13
    src/a_dir                     |    6            6
      src/a_dir/a1_test.jl        |    1            1
        a1                        |    1            1  0.0s
      src/a_dir/a2_test.jl        |    2            2
        a2                        |    2            2  0.0s
      src/a_dir/x_dir             |    3            3
        src/a_dir/x_dir/x_test.jl |    3            3
          z                       |    1            1  0.0s
          y                       |    1            1  0.0s
          x                       |    1            1  0.0s
    src/b_dir                     |          1      1
      src/b_dir/b_test.jl         |          1      1
        b                         |          1      1  0.0s
    src/bar_tests.jl              |    4            4
      bar                         |    4            4  0.0s
    src/foo_test.jl               |    2            2
      foo                         |    2            2  0.0s
ERROR: Some tests did not pass: 12 passed, 1 failed, 0 errored, 0 broken.

```
Now, if a test failed:
```julia
Test Summary:             | Pass  Fail  Total  Time
TestsInSrc                |   12     1     13  0.1s
  src                     |   12     1     13
    src/a_dir             |    6            6
    src/b_dir             |          1      1
      src/b_dir/b_test.jl |          1      1
        b                 |          1      1  0.0s
    src/bar_tests.jl      |    4            4
    src/foo_test.jl       |    2            2
ERROR: Some tests did not pass: 12 passed, 1 failed, 0 errored, 0 broken.
```

(close https://relationalai.atlassian.net/browse/RAI-14060)