### PR TITLE
Log at error level when worker killed + simplify retry logic

### DIFF
--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -301,7 +301,7 @@ function _runtests_in_current_env(
                     # (the first one is a partial mark, full sweep, the next one is a full mark).
                     GC.gc(true)
                     GC.gc(false)
-                    if ts.anynonpass && run_number != max_runs
+                    if any_non_pass(ts) && run_number != max_runs
                         run_number += 1
                         @info "Retrying $(repr(testitem.name)). Run=$run_number."
                     else
@@ -350,6 +350,8 @@ function start_worker(proj_name, nworker_threads, worker_init_expr, ntestitems)
     end)
     return w
 end
+
+any_non_pass(ts::DefaultTestSet) = ts.anynonpass
 
 function record_timeout!(testitem, run_number::Int, timeout_limit::Real)
     timeout_s = round(Int, timeout_limit)
@@ -432,7 +434,7 @@ function start_and_manage_worker(
                 # Run GC to free memory on the worker before next testitem.
                 @debugv 2 "Running GC on $worker"
                 remote_fetch(worker, :(GC.gc(true); GC.gc(false)))
-                if ts.anynonpass && run_number != max_runs
+                if any_non_pass(ts) && run_number != max_runs
                     run_number += 1
                     @info "Retrying $(repr(testitem.name)) on $worker. Run=$run_number."
                 else

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -299,7 +299,7 @@ function _runtests_in_current_env(
                     report_empty_testsets(testitem, ts)
                     if ts.anynonpass && nretries < retry_limit
                         nretries += 1
-                        @info "Retrying $(repr(testitem.name)). Run=$run_number."
+                        @info "Retrying $(repr(testitem.name)). Retry=$nretries."
                     else
                         if nretries > 0
                             @info "Test item $(repr(testitem.name)) passed on retry $nretries."

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -299,7 +299,7 @@ function _runtests_in_current_env(
                     report_empty_testsets(testitem, ts)
                     if ts.anynonpass && nretries < retry_limit
                         nretries += 1
-                        @warn "Test item $(repr(testitem.name)) failed. Retrying. Retry=$nretries."
+                        @info "Retrying $(repr(testitem.name)). Run=$run_number."
                     else
                         if nretries > 0
                             @info "Test item $(repr(testitem.name)) passed on retry $nretries."
@@ -454,11 +454,11 @@ function start_and_manage_worker(
                 @debugv 1 "Test item $(repr(testitem.name)) timed out. Terminating worker $worker"
                 terminate!(worker)
                 wait(worker)
-                @warn "$worker timed out evaluating test item $(repr(testitem.name)) afer $timeout seconds. \
+                @error "$worker timed out evaluating test item $(repr(testitem.name)) afer $timeout seconds. \
                     Recording test error."
                 record_timeout!(testitem, run_number, timeout)
             elseif e isa WorkerTerminatedException
-                @warn "$worker died evaluating test item $(repr(testitem.name)). \
+                @error "$worker died evaluating test item $(repr(testitem.name)). \
                     Recording test error."
                 record_worker_terminated!(testitem, run_number)
             else

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -290,26 +290,23 @@ function _runtests_in_current_env(
             for (i, testitem) in enumerate(testitems.testitems)
                 testitem.workerid[] = Libc.getpid()
                 testitem.eval_number[] = i
-                nretries = 0
-                retry_limit = max(retries, testitem.retries)
-                while nretries ≤ retry_limit
+                run_number = 1
+                max_runs = 1 + max(retries, testitem.retries)
+                while run_number ≤ max_runs
                     res = runtestitem(testitem, ctx; verbose_results, logs)
                     ts = res.testset
-                    print_errors_and_captured_logs(testitem, nretries + 1; logs)
+                    print_errors_and_captured_logs(testitem, run_number; logs)
                     report_empty_testsets(testitem, ts)
-                    if ts.anynonpass && nretries < retry_limit
-                        nretries += 1
-                        @info "Retrying $(repr(testitem.name)). Retry=$nretries."
-                    else
-                        if nretries > 0
-                            @info "Test item $(repr(testitem.name)) passed on retry $nretries."
-                        end
-                        break
-                    end
                     # It takes 2 GCs to do a full mark+sweep
                     # (the first one is a partial mark, full sweep, the next one is a full mark).
                     GC.gc(true)
                     GC.gc(false)
+                    if ts.anynonpass && run_number != max_runs
+                        run_number += 1
+                        @info "Retrying $(repr(testitem.name)). Run=$run_number."
+                    else
+                        break
+                    end
                 end
             end
         elseif !isempty(testitems.testitems)
@@ -404,7 +401,7 @@ function start_and_manage_worker(
         ch = Channel{TestItemResult}(1)
         testitem.workerid[] = worker.pid
         fut = remote_eval(worker, :(ReTestItems.runtestitem($testitem, GLOBAL_TEST_CONTEXT; verbose_results=$verbose_results, logs=$(QuoteNode(logs)))))
-        retry_limit = max(retries, testitem.retries)
+        max_runs = 1 + max(retries, testitem.retries)
         try
             timer = Timer(timeout) do tm
                 close(tm)
@@ -435,7 +432,7 @@ function start_and_manage_worker(
                 # Run GC to free memory on the worker before next testitem.
                 @debugv 2 "Running GC on $worker"
                 remote_fetch(worker, :(GC.gc(true); GC.gc(false)))
-                if ts.anynonpass && (run_number != (1 + retry_limit))
+                if ts.anynonpass && run_number != max_runs
                     run_number += 1
                     @info "Retrying $(repr(testitem.name)) on $worker. Run=$run_number."
                 else
@@ -467,7 +464,7 @@ function start_and_manage_worker(
                 rethrow()
             end
             # Handle retries
-            if run_number == (1 + retry_limit)
+            if run_number == max_runs
                 testitem = next_testitem(testitems, testitem.number[])
                 run_number = 1
             else

--- a/src/junit_xml.jl
+++ b/src/junit_xml.jl
@@ -58,7 +58,7 @@ function JUnitTestCase(ti::TestItem, run_number::Int)
     ts = ti.testsets[run_number]
     counts = JUnitCounts(ts)
     stats = ti.stats[run_number]
-    if !ts.anynonpass
+    if !any_non_pass(ts)
         logs = nothing
         message = nothing
     else

--- a/src/log_capture.jl
+++ b/src/log_capture.jl
@@ -167,7 +167,7 @@ function print_errors_and_captured_logs(
     io, ti::TestItem, run_number::Int; logs=:batched, errors_first::Bool=false,
 )
     ts = ti.testsets[run_number]
-    has_errors = ts.anynonpass
+    has_errors = any_non_pass(ts)
     has_logs = _has_logs(ti, run_number) || any(_has_logs, ti.testsetups)
     if has_errors || logs == :batched
         report_iob = IOContext(IOBuffer(), :color=>Base.get_have_color())


### PR DESCRIPTION
- Log worker killed (due to crash or timeout) as an error-level log message, to make these cases easier to find in the logs, especially as time-outs and potentially even crashes might not have logs containing "error" (nor "fail")
- Make the log messages for retries in the `nworkers=0` and `nworker>0` cases match, simplifying the logic in the process.