### PR TITLE
When `_run=false` don't schedule the testitem

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReTestItems"
 uuid = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
-version = "1.12.1"
+version = "1.12.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -277,7 +277,9 @@ macro testitem(nm, exs...)
             $gettls(:__RE_TEST_PROJECT__, "."),
             $q,
         )
-            if !$_run || $gettls(:__RE_TEST_RUNNING__, false)::$Bool
+            if !$_run
+                $ti
+            elseif $gettls(:__RE_TEST_RUNNING__, false)::$Bool
                 $store_test_item($ti)
                 $ti
             else # We are not in a `runtests` call, so we run the testitem immediately.


### PR DESCRIPTION
`_run::Bool=false` is used for testing the `@testitem` macro itself, as it disables the running of the `@testitem` and instead just returns the created `TestItem` object, which can then be inspected as part of testing... however, we were accidentally only respecting `_run` when outside of a `runtests()` call. If inside a `runtests()` call, we were still scheduling the test-item to run... but we don't want the test-item to ever run if `_run=false`.