### PR TITLE
If a worker doesn't start successfully then retry

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReTestItems"
 uuid = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
-version = "1.14.0"
+version = "1.15.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -371,7 +371,7 @@ end
 # Want to be somewhat robust to workers possibly terminating during start up (e.g. due to
 # the `worker_init_expr`).
 # The number of retries and delay between retries is currently arbitrary...
-# we want to retry at least once, and we give a slight delay in case their are resources
+# we want to retry at least once, and we give a slight delay in case there are resources
 # that need to be cleaned up before a new worker would be able to start successfully.
 const _NRETRIES = 2
 const _RETRY_DELAY_SECONDS = 1

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -338,16 +338,16 @@ function _runtests_in_current_env(
                 end
             end
         end
-    Test.TESTSET_PRINT_ENABLE[] = true # reenable printing so our `finish` prints
-    record_results!(testitems)
-    report && write_junit_file(proj_name, dirname(projectfile), testitems.graph.junit)
-    Test.finish(testitems) # print summary of total passes/failures/errors
-finally
-    Test.TESTSET_PRINT_ENABLE[] = true
-    # Cleanup test setup logs
-    foreach(rm, filter(endswith(".log"), readdir(RETESTITEMS_TEMP_FOLDER, join=true)))
-end
-return nothing
+        Test.TESTSET_PRINT_ENABLE[] = true # reenable printing so our `finish` prints
+        record_results!(testitems)
+        report && write_junit_file(proj_name, dirname(projectfile), testitems.graph.junit)
+        Test.finish(testitems) # print summary of total passes/failures/errors
+    finally
+        Test.TESTSET_PRINT_ENABLE[] = true
+        # Cleanup test setup logs
+        foreach(rm, filter(endswith(".log"), readdir(RETESTITEMS_TEMP_FOLDER, join=true)))
+    end
+    return nothing
 end
 
 # Start a new `Worker` with `nworker_threads` threads and evaluate `worker_init_expr` on it.

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -444,6 +444,7 @@ function manage_worker(
     timeout::Real, retries::Int, verbose_results::Bool, debug::Int, report::Bool, logs::Symbol
 )
     ntestitems = length(testitems.testitems)
+    run_number = 1
     while testitem !== nothing
         ch = Channel{TestItemResult}(1)
         testitem.workerid[] = worker.pid

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -329,7 +329,7 @@ function _runtests_in_current_env(
             # Now all workers are started, we can begin processing test items.
             @info "Starting evaluating test items"
             starting = get_starting_testitems(testitems, nworkers)
-            @sync for (i, w) in enumerate(worker)
+            @sync for (i, w) in enumerate(workers)
                 ti = starting[i]
                 @spawn begin
                     with_logger(original_logger) do

--- a/test/integrationtests.jl
+++ b/test/integrationtests.jl
@@ -769,4 +769,20 @@ end
     @test ts.time_end - ts.time_start ≈ timeout
 end
 
+@testset "worker crashes immediately" begin
+    file = joinpath(TEST_FILES_DIR, "_happy_tests.jl")
+    worker_init_expr = quote
+        if iseven(Libc.getpid())
+            @eval ccall(:abort, Cvoid, ())
+            # sleep(10)
+        end
+    end
+    captured = IOCapture.capture() do
+        encased_testset() do
+            runtests(file; nworkers=4, worker_init_expr)
+        end
+    end
+    @show captured
+end
+
 end # integrationtests.jl testset

--- a/test/integrationtests.jl
+++ b/test/integrationtests.jl
@@ -772,8 +772,10 @@ end
 @testset "worker always crashes immediately" begin
     file = joinpath(TEST_FILES_DIR, "_happy_tests.jl")
 
-    terminated_err_log_1 = r"Error: Worker\(pid=\d+, terminated=true, termsignal=6\) terminated unexpectedly. Starting new worker \(retry 1/2\)."
-    terminated_err_log_2 = r"Error: Worker\(pid=\d+, terminated=true, termsignal=6\) terminated unexpectedly. Starting new worker \(retry 2/2\)."
+    # We have occassionally seen the Process exist with the expected signal.
+    @assert typemin(Int32) == -2147483648
+    terminated_err_log_1 = r"Error: Worker\(pid=\d+, terminated=true, termsignal=(6|-2147483648)\) terminated unexpectedly. Starting new worker \(retry 1/2\)."
+    terminated_err_log_2 = r"Error: Worker\(pid=\d+, terminated=true, termsignal=(6|-2147483648)\) terminated unexpectedly. Starting new worker \(retry 2/2\)."
 
     worker_init_expr = :(@eval ccall(:abort, Cvoid, ()))
     # We don't use IOCapture for capturing logs as that seems to hang when the worker crashes.

--- a/test/integrationtests.jl
+++ b/test/integrationtests.jl
@@ -808,7 +808,9 @@ end
             @eval ccall(:abort, Cvoid, ())
         end
     end
-    terminated_err_log_1 = r"Error: Worker\(pid=\d+, terminated=true, termsignal=6\) terminated unexpectedly. Starting new worker \(retry 1/2\)."
+    # We have occassionally seen the Process exist with the expected signal.
+    @assert typemin(Int32) == -2147483648
+    terminated_err_log_1 = r"Error: Worker\(pid=\d+, terminated=true, termsignal=(6|-2147483648)\) terminated unexpectedly. Starting new worker \(retry 1/2\)."
     # We don't use IOCapture for capturing logs as that seems to hang when the worker crashes.
     try
         mktemp() do io, path

--- a/test/integrationtests.jl
+++ b/test/integrationtests.jl
@@ -771,10 +771,10 @@ end
 
 @testset "worker always crashes immediately" begin
     file = joinpath(TEST_FILES_DIR, "_happy_tests.jl")
-#
+
     terminated_err_log_1 = r"Error: Worker\(pid=\d+, terminated=true, termsignal=6\) terminated unexpectedly. Starting new worker \(retry 1/2\)."
     terminated_err_log_2 = r"Error: Worker\(pid=\d+, terminated=true, termsignal=6\) terminated unexpectedly. Starting new worker \(retry 2/2\)."
-#
+
     worker_init_expr = :(@eval ccall(:abort, Cvoid, ()))
     # We don't use IOCapture for capturing logs as that seems to hang when the worker crashes.
     mktemp() do io, path

--- a/test/integrationtests.jl
+++ b/test/integrationtests.jl
@@ -609,6 +609,8 @@ end
 @testset "test retrying failing testitem" begin
     file = joinpath(TEST_FILES_DIR, "_retry_tests.jl")
     # This directory must match what's set in `_retry_tests`
+    # Use `/tmp` directly instead of `mktemp` to remove chance that files are cleaned up
+    # as soon as the worker process crashes.
     tmpdir = joinpath("/tmp", "JL_RETESTITEMS_TEST_TMPDIR")
     # must run with `testitem_timeout < 20` for test to timeout as expected.
     # and must run with `nworkers > 0` for retries to be supported.
@@ -798,9 +800,11 @@ end
 @testset "worker crashes immediately but succeeds on retry" begin
     file = joinpath(TEST_FILES_DIR, "_happy_tests.jl")
     nworkers = 4
+    # use `/tmp` directly instead of `mktemp` to remove chance that files are cleaned up
+    # as soon as the worker process crashes.
     tmpdir = joinpath("/tmp", "JL_RETESTITEMS_TEST_TMPDIR")
     tmpfile = joinpath(tmpdir, "worker_crash")
-    # First worker start should crash, then all subsequent worker starts should succeed.
+    # At least one worker should crash, but all workers should succeed upon a retry.
     worker_init_expr = quote
         if !isfile($tmpfile)
             mkpath($tmpdir)

--- a/test/testfiles/_happy_tests.jl
+++ b/test/testfiles/_happy_tests.jl
@@ -1,0 +1,11 @@
+@testitem "happy 1" begin
+    @test 1 == 1
+end
+
+@testitem "happy 2" begin
+    @test 2 == 2
+end
+
+@testitem "happy 3" begin
+    @test 3 == 3
+end


### PR DESCRIPTION
...but wait for the requested number of workers to start successfully before running any tests (i.e. throw before running tests if we failed to start the requested number of workers).

Similarly, allow retry when starting _replacement_ workers (for workers that died whilst running a test)

In other words, before we were assuming workers could only die whilst a test was running whereas now we handle the possibly of workers dying before they start running a test.

This potentially adds a little latency (increasing time-to-first-test), even if all workers start successfully first try, since we know wait on all workers before starting any tests, whereas previously a worker would start running tests as soon as it was ready (not waiting for all workers to be ready). Workers are still started in parallel, so the latency should be minimal. And so long as starting worker processes is very fast (relative to running tests), i.e. so long as `worker_init_expr` isn't something very time consuming, then this latency from synchronizing should hopefully be acceptable to users even if a retry is needed.

### Examples

- Logs if N workers fail to start even on retry:

```julia
julia> runtests(file; nworkers=4, worker_init_expr)
[ Info: Scanning for test items in project `ReTestItems` at paths: /Users/nickr/repos/ReTestItems.jl/test/testfiles/_happy_tests.jl
[ Info: Finished scanning for test items in 0.06 seconds. Scheduling 3 tests on pid 37946 with 4 worker processes and 2 threads per worker.
[ Info: Starting test workers
  Worker 75750:  [ Info: Starting test worker 3 on pid = 75750, with 2 threads
  Worker 75750:  signal (6): Abort trap: 6
  Worker 75750:  in expression starting at none:1
  Worker 75750:  __pthread_kill at /usr/lib/system/libsystem_kernel.dylib (unknown line)
┌ Error: Worker(pid=75750, terminated=true, termsignal=6) terminated unexpectedly. Starting new worker (retry 1/2).
└ @ ReTestItems ~/repos/ReTestItems.jl/src/ReTestItems.jl:387
  Worker 75751:  [ Info: Starting test worker 4 on pid = 75751, with 2 threads
  Worker 75749:  [ Info: Starting test worker 2 on pid = 75749, with 2 threads
  Worker 75748:  [ Info: Starting test worker 1 on pid = 75748, with 2 threads
  Worker 75748:  signal (6): Abort trap: 6
  Worker 75748:  in expression starting at none:1
  Worker 75748:  __pthread_kill at /usr/lib/system/libsystem_kernel.dylib (unknown line)
┌ Error: Worker(pid=75748, terminated=true, termsignal=6) terminated unexpectedly. Starting new worker (retry 1/2).
└ @ ReTestItems ~/repos/ReTestItems.jl/src/ReTestItems.jl:387
  Worker 75865:  [ Info: Starting test worker 3 on pid = 75865, with 2 threads
  Worker 75866:  [ Info: Starting test worker 1 on pid = 75866, with 2 threads
  Worker 75866:  signal (6): Abort trap: 6
  Worker 75866:  in expression starting at none:1
┌ Error: Worker(pid=75866, terminated=true, termsignal=6) terminated unexpectedly. Starting new worker (retry 2/2).
└ @ ReTestItems ~/repos/ReTestItems.jl/src/ReTestItems.jl:387
  Worker 75970:  [ Info: Starting test worker 1 on pid = 75970, with 2 threads
  Worker 75970:  signal (6): Abort trap: 6
  Worker 75970:  in expression starting at none:1
ERROR: TaskFailedException

    nested task error: ReTestItems.Workers.WorkerTerminatedException(Worker(pid=75970, terminated=true, termsignal=6))
```

- Logs if N workers successfully start given retries:

```julia
julia> runtests(file; nworkers=4, worker_init_expr)
[ Info: Scanning for test items in project `ReTestItems` at paths: /Users/nickr/repos/ReTestItems.jl/test/testfiles/_happy_tests.jl
[ Info: Finished scanning for test items in 0.05 seconds. Scheduling 3 tests on pid 37946 with 4 worker processes and 2 threads per worker.
[ Info: Starting test workers
  Worker 88298:  [ Info: Starting test worker 1 on pid = 88298, with 2 threads
  Worker 88299:  [ Info: Starting test worker 2 on pid = 88299, with 2 threads
  Worker 88298:  signal (6): Abort trap: 6
  Worker 88298:  in expression starting at none:1
  Worker 88298:  __pthread_kill at /usr/lib/system/libsystem_kernel.dylib (unknown line)
┌ Error: Worker(pid=88298, terminated=true, termsignal=6) terminated unexpectedly. Starting new worker (retry 1/2).
└ @ ReTestItems ~/repos/ReTestItems.jl/src/ReTestItems.jl:387
  Worker 88301:  [ Info: Starting test worker 4 on pid = 88301, with 2 threads
  Worker 88300:  [ Info: Starting test worker 3 on pid = 88300, with 2 threads
  Worker 88404:  [ Info: Starting test worker 1 on pid = 88404, with 2 threads
[ Info: Starting evaluating test items
  Worker 88300:  16:59:11 | START (3/3) test item "happy 3" at test/testfiles/_happy_tests.jl:9
  Worker 88299:  16:59:11 | START (2/3) test item "happy 2" at test/testfiles/_happy_tests.jl:5
  Worker 88404:  16:59:11 | START (1/3) test item "happy 1" at test/testfiles/_happy_tests.jl:1
  Worker 88300:  16:59:11 | DONE  (3/3) test item "happy 3" <0.1 secs (93.4% compile), 69.42 K allocs (4.200 MB)
  Worker 88404:  16:59:11 | DONE  (1/3) test item "happy 1" <0.1 secs (94.1% compile), 69.42 K allocs (4.200 MB)
  Worker 88299:  16:59:11 | DONE  (2/3) test item "happy 2" <0.1 secs (93.9% compile), 69.42 K allocs (4.200 MB)
Test Summary:                        | Pass  Total  Time
ReTestItems                          |    3      3  3.2s
  test                               |    3      3
    test/testfiles                   |    3      3
      test/testfiles/_happy_tests.jl |    3      3
        happy 1                      |    1      1  0.1s
        happy 2                      |    1      1  0.1s
        happy 3                      |    1      1  0.1s
```

