### PR TITLE
Add ability to pass an expression to run after every testitem

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReTestItems"
 uuid = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
-version = "1.16.0"
+version = "1.17.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -882,7 +882,7 @@ function runtestitem(
         # add the `test_end_expr` to a module to be run after the test item
         test_end_body = copy(body)
         append!(test_end_body.args, test_end_expr.args)
-        softscope_all!(test_end)
+        softscope_all!(test_end_body)
         test_end_mod_expr = :(module $(gensym(name * " test_end")) end)
         test_end_mod_expr.args[3] = test_end_body
 

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -872,7 +872,7 @@ function runtestitem(
         # add the `test_end_expr` to a module to be run after the test item
         test_end_body = copy(body)
         test_end_mod_expr = :(module $(gensym(name * " test_end")) end)
-        push!(test_end_body.args, test_end_expr)
+        append!(test_end_body.args, test_end_expr.args)
         test_end_mod_expr.args[3] = test_end_body
 
         # add our @testitem quoted code to module body expr

--- a/test/_integration_test_tools.jl
+++ b/test/_integration_test_tools.jl
@@ -6,6 +6,7 @@
 # (ii) do _not_ want expected fail/errors to cause ReTestItems' tests to fail/error
 # This is not `@test_throws` etc, because we're not testing that the code fails/errors
 # we're testing that _the tests themselves_ fail/error.
+using Test
 
 """
     EncasedTestSet(desc, results) <: AbstractTestset

--- a/test/integrationtests.jl
+++ b/test/integrationtests.jl
@@ -934,6 +934,7 @@ end
             runtests(; nworkers=1, worker_init_expr, test_end_expr)
         end
         @test !all_passed(results_with_end)
+        @test n_passed(results_with_end) ≥ 1
         @test length(failures(results_with_end)) ≥ 1
     end
 end

--- a/test/integrationtests.jl
+++ b/test/integrationtests.jl
@@ -875,8 +875,8 @@ end
         @test contains(
             c3.output,
             r"""
-            Test Summary:                        \| Pass  Total  Time
-            ReTestItems                          \|    6      6  \d.\ds
+            Test Summary: \s* \| Pass  Total  Time
+            ReTestItems   \s* \|    6      6  \d.\ds
             """
         )
         # Test that for a failing `test_end_expr` we report the failing tests, including

--- a/test/integrationtests.jl
+++ b/test/integrationtests.jl
@@ -21,7 +21,7 @@ const TEST_PKG_DIR = joinpath(_TEST_DIR, "packages")
 
 # Note "DontPass.jl" is handled specifically below, as it's the package which doesn't have
 # passing tests. Other packages should pass tests and be added here:
-const TEST_PKGS = ("NoDeps.jl", "TestsInSrc.jl", "TestProjectFile.jl", "TestEndExpr.jl")
+const TEST_PKGS = ("NoDeps.jl", "TestsInSrc.jl", "TestProjectFile.jl")
 
 include(joinpath(_TEST_DIR, "_integration_test_tools.jl"))
 
@@ -830,19 +830,24 @@ end
 @testset "test_end_expr" begin
     # `_happy_tests.jl` has 3 testitems with 1 passing test each.
     file = joinpath(TEST_FILES_DIR, "_happy_tests.jl")
+    # Test that running a `test_end_expr` after each testitem works;
+    # should work exactly the same no matter if we use workers or not.
     @testset "nworkers=$nworkers" for nworkers in (0, 1, 2)
         @testset "post-testitem checks pass" begin
+            # Here there should be two extra passing tests per testitem.
             test_end1 = quote
                 @test 1 == 1
+                @test 2 == 2
             end
             results1 = encased_testset() do
                 runtests(file; nworkers, test_end_expr=test_end1)
             end
-            @test n_tests(results1) == 6
+            @test n_tests(results1) == 9
             @test all_passed(results1)
         end
 
         @testset "post-testitem checks fail" begin
+            # Here there should be one extra failing tests per testitem.
             test_end2 = quote
                 @test 1 == 2
             end
@@ -851,58 +856,85 @@ end
             end
             @test n_tests(results2) == 6
             @test n_passed(results2) == 3
+            @test length(failures(results2)) == 3
         end
     end
     @testset "report printing" begin
         using IOCapture
+        # Test that a passing `test_end_expr` we just report the total number of tests
+        # including the extra tests, which here is an extra 1 test per testitem.
         test_end3 = quote @test true end
         results3 = encased_testset() do
             runtests(file; nworkers=1, test_end_expr=test_end3)
         end
-        c = IOCapture.capture() do
+        c3 = IOCapture.capture() do
             Test.print_test_results(results3)
         end
         @assert n_tests(results3) == 6
         @assert all_passed(results3)
         @test contains(
-            c.output,
+            c3.output,
             r"""
             Test Summary:                        \| Pass  Total  Time
             ReTestItems                          \|    6      6  \d.\ds
             """
         )
+        # Test that for a failing `test_end_expr` we report the failing tests, including
+        # the `@testset` which we have put inside the `test_end_expr`.
         test_end4 = quote
             @testset "post-testitem" begin
-                @test false end
+                @test false
             end
         end
         results4 = encased_testset() do
             runtests(file; nworkers=1, test_end_expr=test_end4)
         end
-        @assert n_tests(results4) == 6
-        @assert n_passed(results4) == 3
+        @test n_tests(results4) == 6
+        @test n_passed(results4) == 3
+        c4 = IOCapture.capture() do
+            Test.print_test_results(results4)
+        end
         @test contains(
-            c.output,
+            c4.output,
             r"""
             Test Summary:                        \| Pass  Fail  Total  Time
             ReTestItems                          \|    3     3      6  \d.\ds
             """
         )
+        @test contains(
+            c4.output,
+            r"""
+            \s*    happy 1                      \|    1     1      2  \d.\ds
+            \s*      post-testitem              \|          1      1  \d.\ds
+            """
+        )
     end
     @testset "TestEndExpr.jl package" begin
+        # Test that the TestEndExpr.jl package passes without the `test_end_expr`
+        # checking for danginling pins.
+        worker_init_expr = quote
+            using TestEndExpr: init_pager!
+            init_pager!()
+        end
+        results_no_end = with_test_package("TestEndExpr.jl") do
+            runtests(; nworkers=1, worker_init_expr)
+        end
+        @test all_passed(results_no_end)
+        # Test that the TestEndExpr.jl package fails when we add the `test_end_expr`
+        # checking for danginling pins.
         test_end_expr = quote
+            using TestEndExpr: GLOBAL_PAGER, count_pins
             p = GLOBAL_PAGER[]
             (isnothing(p) || isempty(p.pages)) && return nothing
             @testset "no pins left at end of test" begin
                 @test count_pins(p) == 0
             end
         end
-        results1 = with_test_package("TestEndExpr.jl") do
-            runtests(; test_end_expr)
+        results_with_end = with_test_package("TestEndExpr.jl") do
+            runtests(; nworkers=1, worker_init_expr, test_end_expr)
         end
-        results2 = with_test_package("TestEndExpr.jl") do
-            runtests(; test_end_expr)
-        end
+        @test !all_passed(results_with_end)
+        @test length(failures(results_with_end)) ≥ 1
     end
 end
 

--- a/test/integrationtests.jl
+++ b/test/integrationtests.jl
@@ -875,8 +875,8 @@ end
         @test contains(
             c3.output,
             r"""
-            Test Summary: \s* \| Pass  Total  Time
-            ReTestItems   \s* \|    6      6  \d.\ds
+            Test Summary: \| Pass  Total  Time
+            ReTestItems   \|    6      6  \d.\ds
             """
         )
         # Test that for a failing `test_end_expr` we report the failing tests, including

--- a/test/integrationtests.jl
+++ b/test/integrationtests.jl
@@ -21,7 +21,7 @@ const TEST_PKG_DIR = joinpath(_TEST_DIR, "packages")
 
 # Note "DontPass.jl" is handled specifically below, as it's the package which doesn't have
 # passing tests. Other packages should pass tests and be added here:
-const TEST_PKGS = ("NoDeps.jl", "TestsInSrc.jl", "TestProjectFile.jl")
+const TEST_PKGS = ("NoDeps.jl", "TestsInSrc.jl", "TestProjectFile.jl", "TestEndExpr.jl")
 
 include(joinpath(_TEST_DIR, "_integration_test_tools.jl"))
 
@@ -823,6 +823,85 @@ end
             # Test we were then able to run all tests successfully.
             @test n_tests(results) == 3
             @test all_passed(results) == 1
+        end
+    end
+end
+
+@testset "test_end_expr" begin
+    # `_happy_tests.jl` has 3 testitems with 1 passing test each.
+    file = joinpath(TEST_FILES_DIR, "_happy_tests.jl")
+    @testset "nworkers=$nworkers" for nworkers in (0, 1, 2)
+        @testset "post-testitem checks pass" begin
+            test_end1 = quote
+                @test 1 == 1
+            end
+            results1 = encased_testset() do
+                runtests(file; nworkers, test_end_expr=test_end1)
+            end
+            @test n_tests(results1) == 6
+            @test all_passed(results1)
+        end
+
+        @testset "post-testitem checks fail" begin
+            test_end2 = quote
+                @test 1 == 2
+            end
+            results2 = encased_testset() do
+                runtests(file; nworkers, test_end_expr=test_end2)
+            end
+            @test n_tests(results2) == 6
+            @test n_passed(results2) == 3
+        end
+    end
+    @testset "report printing" begin
+        using IOCapture
+        test_end3 = quote @test true end
+        results3 = encased_testset() do
+            runtests(file; nworkers=1, test_end_expr=test_end3)
+        end
+        c = IOCapture.capture() do
+            Test.print_test_results(results3)
+        end
+        @assert n_tests(results3) == 6
+        @assert all_passed(results3)
+        @test contains(
+            c.output,
+            r"""
+            Test Summary:                        \| Pass  Total  Time
+            ReTestItems                          \|    6      6  \d.\ds
+            """
+        )
+        test_end4 = quote
+            @testset "post-testitem" begin
+                @test false end
+            end
+        end
+        results4 = encased_testset() do
+            runtests(file; nworkers=1, test_end_expr=test_end4)
+        end
+        @assert n_tests(results4) == 6
+        @assert n_passed(results4) == 3
+        @test contains(
+            c.output,
+            r"""
+            Test Summary:                        \| Pass  Fail  Total  Time
+            ReTestItems                          \|    3     3      6  \d.\ds
+            """
+        )
+    end
+    @testset "TestEndExpr.jl package" begin
+        test_end_expr = quote
+            p = GLOBAL_PAGER[]
+            (isnothing(p) || isempty(p.pages)) && return nothing
+            @testset "no pins left at end of test" begin
+                @test count_pins(p) == 0
+            end
+        end
+        results1 = with_test_package("TestEndExpr.jl") do
+            runtests(; test_end_expr)
+        end
+        results2 = with_test_package("TestEndExpr.jl") do
+            runtests(; test_end_expr)
         end
     end
 end

--- a/test/packages/README.md
+++ b/test/packages/README.md
@@ -13,3 +13,4 @@ See `test/integrationtests.jl`.
 - *TestsInSrc.jl* - A package which has all of its `@testitems` in the `src/` directory.
 - *TestProjectFile.jl* - A package which has test-only dependencies declared in a `test/Project.toml`.
 - *MonoRepo.jl* - A package which depends on local, unregistered sub-packages. See `MonoRepo.jl/README.md`.
+- *TestEndExpr.jl* - A package which requires users to uphold an invariant which we would want to test is being upheld by all code run in the tests. This provides a use-case for the `test_end_expr` functionality.

--- a/test/packages/TestEndExpr.jl/Manifest.toml
+++ b/test/packages/TestEndExpr.jl/Manifest.toml
@@ -1,0 +1,154 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.9.2"
+manifest_format = "2.0"
+project_hash = "31dabfddf1e36ecf2dc5cff56cdddc361b29f16f"
+
+[[deps.ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+version = "1.1.1"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[deps.Downloads]]
+deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+version = "1.6.0"
+
+[[deps.FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+
+[[deps.InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[deps.LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+version = "0.6.3"
+
+[[deps.LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+version = "7.84.0+0"
+
+[[deps.LibGit2]]
+deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[deps.LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+version = "1.10.2+0"
+
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[deps.LoggingExtras]]
+deps = ["Dates", "Logging"]
+git-tree-sha1 = "a03c77519ab45eb9a34d3cfe2ca223d79c064323"
+uuid = "e6f89c97-d47a-5376-807f-9c37f3926c36"
+version = "1.0.1"
+
+[[deps.Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[deps.MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+version = "2.28.2+0"
+
+[[deps.MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+version = "2022.10.11"
+
+[[deps.NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+version = "1.2.0"
+
+[[deps.Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+version = "1.9.2"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[deps.REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[deps.Random]]
+deps = ["SHA", "Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[deps.ReTestItems]]
+deps = ["Dates", "Logging", "LoggingExtras", "Pkg", "Serialization", "Sockets", "Test", "TestEnv"]
+path = "../../.."
+uuid = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
+version = "1.16.0"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[deps.Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+[[deps.Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+version = "1.10.0"
+
+[[deps.Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[deps.TestEnv]]
+deps = ["Pkg"]
+git-tree-sha1 = "dca851f0824deaf6a73ef1308fe7b2c53239c710"
+uuid = "1e6cf692-eddd-4d53-88a5-2d735e33781b"
+version = "1.100.1"
+
+[[deps.UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[deps.Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+version = "1.2.13+0"
+
+[[deps.nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+version = "1.48.0+0"
+
+[[deps.p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+version = "17.4.0+0"

--- a/test/packages/TestEndExpr.jl/Project.toml
+++ b/test/packages/TestEndExpr.jl/Project.toml
@@ -1,0 +1,13 @@
+name = "TestEndExpr"
+uuid = "4560ce14-60c1-53a9-8c5b-16f535851c77"
+version = "0.0.0"
+
+[deps]
+ReTestItems = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
+
+[extras]
+ReTestItems = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["ReTestItems", "Test"]

--- a/test/packages/TestEndExpr.jl/README.md
+++ b/test/packages/TestEndExpr.jl/README.md
@@ -1,0 +1,14 @@
+# TestEndExpr.jl
+
+A package for the sake of testing the `test_end_expr` functionality of `ReTestItems.runtests`.
+
+We want to emulate a situation where correct usage of a package requires users to uphold a certain invariant.
+In this very simplified example, `Page` objects must be pinned via `pin!` when in use, and subsequently unpinned via `unpin!` when no longer in use; there must be an equal number of `pin!` and `unpin!` calls in order to avoid a memory leak.
+
+We want to be able to write potentially very many `@testitem`s which test all sorts of functionality that use `Page`s under the hood.
+But we also want to test that every such usage correctly upholds the invariant, i.e. no `Page` is left "pinned" at the end of the `@testitem`.
+
+We could do that by manually adding something like `@test no_pages_pinned()` as the last line of every `@testitem`, but we might not want to rely on test authors remembering to do this.
+So instead, we want to use `test_end_expr` to declare a block of code like `@test no_pages_pinned()` to automatically run at the end of every `@testitem`.
+
+In the tests of this package, we define test-items that **pass** when run without such a `test_end_expr`, but at least one of the test-items **fails** when run with a `test_end_expr` testing that no pages are left pinned.

--- a/test/packages/TestEndExpr.jl/src/TestEndExpr.jl
+++ b/test/packages/TestEndExpr.jl/src/TestEndExpr.jl
@@ -1,0 +1,43 @@
+module TestEndExpr
+
+export GLOBAL_PAGER, Pager, Page, pin!, unpin!, read_content, count_pins
+
+mutable struct Page
+    content::Any
+    @atomic pincount::Int
+    function Page(x)
+        p = new(x, 0)
+        @assert !isnothing(GLOBAL_PAGER[])
+        push!(GLOBAL_PAGER[].pages, p)
+        return p
+    end
+end
+
+function pin!(p::Page)
+    @atomic p.pincount += 1
+end
+function unpin!(p::Page)
+    @atomic p.pincount -= 1
+end
+function read_content(p::Page)
+    @assert p.pincount > 0
+    return p.content
+end
+count_pins(p::Page) = p.pincount
+
+struct Pager
+    pages::Vector{Page}
+end
+Pager() = Pager(Page[])
+
+function count_pins(p::Pager)
+    return sum(count_pins, p.pages; init=0)
+end
+
+const GLOBAL_PAGER = Ref{Union{Nothing,Pager}}(nothing)
+
+# function __init__()
+#     GLOBAL_PAGER[] = Pager()
+# end
+
+end # module

--- a/test/packages/TestEndExpr.jl/src/TestEndExpr.jl
+++ b/test/packages/TestEndExpr.jl/src/TestEndExpr.jl
@@ -1,43 +1,56 @@
 module TestEndExpr
 
-export GLOBAL_PAGER, Pager, Page, pin!, unpin!, read_content, count_pins
+export Pager, Page, good_read, bad_read
 
 mutable struct Page
     content::Any
     @atomic pincount::Int
     function Page(x)
-        p = new(x, 0)
+        p = new(x, 0) # 1 would be more realistic, but 0 keeps things simpler for our tests.
         @assert !isnothing(GLOBAL_PAGER[])
-        push!(GLOBAL_PAGER[].pages, p)
+        @lock GLOBAL_PAGER[].lock push!(GLOBAL_PAGER[].pages, p)
         return p
     end
 end
 
-function pin!(p::Page)
-    @atomic p.pincount += 1
-end
-function unpin!(p::Page)
-    @atomic p.pincount -= 1
-end
+pin!(p::Page) = @atomic p.pincount += 1
+unpin!(p::Page) = @atomic p.pincount -= 1
+
 function read_content(p::Page)
     @assert p.pincount > 0
     return p.content
 end
-count_pins(p::Page) = p.pincount
+
+function good_read(p::Page)
+    pin!(p)
+    content = read_content(p)
+    unpin!(p)
+    return content
+end
+
+function bad_read(p::Page)
+    pin!(p)
+    content = read_content(p)
+    #= No `unpin!(p)` call! =#
+    return content
+end
 
 struct Pager
     pages::Vector{Page}
+    lock::ReentrantLock
 end
-Pager() = Pager(Page[])
+Pager() = Pager(Page[], ReentrantLock())
 
+## `Pager` is free to delete pages if they are not pinned.
+## Commented out since it is just for example and not used.
+# cleanup!(p::Pager) = @lock p.lock deleteat!(p.pages, count_pins.(p.pages) .== 0)
+
+count_pins(p::Page) = p.pincount
 function count_pins(p::Pager)
-    return sum(count_pins, p.pages; init=0)
+    return @lock p.lock sum(count_pins, p.pages; init=0)
 end
 
 const GLOBAL_PAGER = Ref{Union{Nothing,Pager}}(nothing)
-
-# function __init__()
-#     GLOBAL_PAGER[] = Pager()
-# end
+init_pager!() = isnothing(GLOBAL_PAGER[]) && (GLOBAL_PAGER[] = Pager())
 
 end # module

--- a/test/packages/TestEndExpr.jl/test/page_tests.jl
+++ b/test/packages/TestEndExpr.jl/test/page_tests.jl
@@ -1,14 +1,11 @@
 @testitem "correct usage" begin
     p = Page("Once upon a time")
-    pin!(p)
-    content = read_content(p)
-    unpin!(p)
-    @test content == "Once upon a time"
+    # `good_read` successfully reads the page and leaves it unpinned.
+    @test good_read(p) == "Once upon a time"
 end
+
 @testitem "incorrect usage" begin
     p = Page("A long time ago")
-    pin!(p)
-    content = read_content(p)
-    #= No unpin! call =#
-    @test content == "A long time ago"
+    # `bad_read` successfully reads the page *but forgets to unpin it!*
+    @test bad_read(p) == "A long time ago"
 end

--- a/test/packages/TestEndExpr.jl/test/page_tests.jl
+++ b/test/packages/TestEndExpr.jl/test/page_tests.jl
@@ -1,0 +1,14 @@
+@testitem "correct usage" begin
+    p = Page("Once upon a time")
+    pin!(p)
+    content = read_content(p)
+    unpin!(p)
+    @test content == "Once upon a time"
+end
+@testitem "incorrect usage" begin
+    p = Page("A long time ago")
+    pin!(p)
+    content = read_content(p)
+    #= No unpin! call =#
+    @test content == "A long time ago"
+end

--- a/test/packages/TestEndExpr.jl/test/runtests.jl
+++ b/test/packages/TestEndExpr.jl/test/runtests.jl
@@ -2,10 +2,14 @@ using ReTestItems
 using TestEndExpr
 
 const worker_init_expr = quote
-    using TestEndExpr
-    GLOBAL_PAGER[] = Pager()
+    using TestEndExpr: init_pager!
+    init_pager!()
 end
 
+## This is the sort of `test_end_expr` we would want to run
+## We don't use this here in the TestEndExpr.jl tests, so that all the tests pass.
+## Instead we set in `ReTestItems/test/integrationtests.jl` so we can test
+## that such a `test_end_expr` causes the tests to fail.
 # const test_end_expr = quote
 #     p = GLOBAL_PAGER[]
 #     (isnothing(p) || isempty(p.pages)) && return nothing

--- a/test/packages/TestEndExpr.jl/test/runtests.jl
+++ b/test/packages/TestEndExpr.jl/test/runtests.jl
@@ -1,0 +1,17 @@
+using ReTestItems
+using TestEndExpr
+
+const worker_init_expr = quote
+    using TestEndExpr
+    GLOBAL_PAGER[] = Pager()
+end
+
+# const test_end_expr = quote
+#     p = GLOBAL_PAGER[]
+#     (isnothing(p) || isempty(p.pages)) && return nothing
+#     @testset "no pins left at end of test" begin
+#         @test count_pins(p) == 0
+#     end
+# end
+
+runtests(TestEndExpr; nworkers=1, worker_init_expr)


### PR DESCRIPTION
Support passing to `runtests` an expression to run on the worker process immediately after each `@testitem` has been run.

This is useful when you want to guarantee that all the code being exercised by your tests upholds some invariant. For example, suppose you're testing a system that does some manual memory management, for which is crucial that all resources that get marked in-use subsequently get marker as free. We could add to every single test-item a final line `@test everything_got_freed()`, which is probably a good choice for a small enough test suite, but this has a few downsides especially for larger code-bases: (i) it is easy for this line to be forgotten especially when there are many developers who now all need to remember to add this, (ii) it can add up to a lot of extra code when you've many hundreds or thousands of test-items, (iii) it arguably isn't the right place for this test if we want it to run on test-items that are for much higher-level code (that is built some layers up from the manual memory management in our example), even though it might be interesting to run this test after the high-level code (since that high-level code could have combined some utilities provided a middle-layer in an interesting way that exposes an issue with how the low-level memory management code is being used); by keeping the low-level check in the `test_end_expr` we can run it on every test-item without every developer having to be responsible for it.

FYI @li1