### PR TITLE
Allow setting the `logs` argument via the environment

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReTestItems"
 uuid = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
-version = "1.18.1"
+version = "1.19.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReTestItems"
 uuid = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
-version = "1.18.0"
+version = "1.18.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -203,7 +203,7 @@ function runtests(
     name::Union{Regex,AbstractString,Nothing}=nothing,
     tags::Union{Symbol,AbstractVector{Symbol},Nothing}=nothing,
     report::Bool=parse(Bool, get(ENV, "RETESTITEMS_REPORT", "false")),
-    logs::Symbol=default_log_display_mode(report, nworkers),
+    logs::Symbol=Symbol(get(ENV, "RETESTITEMS_LOGS", default_log_display_mode(report, nworkers))),
     verbose_results::Bool=(logs !== :issues && isinteractive()),
     test_end_expr::Expr=Expr(:block),
 )

--- a/test/_test_log_capture.jl
+++ b/test/_test_log_capture.jl
@@ -1,6 +1,6 @@
 # This file defines tests that are run (under various configurations) by `test/log_capture.jl`.
 using ReTestItems, Test, Logging, IOCapture
-const log_display = Symbol(ENV["LOG_DISPLAY"])
+const log_display = Symbol(ENV["RETESTITEMS_LOGS"])
 
 @testset "log capture logs=$(repr(log_display))" begin
     @testset "TestItem" begin

--- a/test/log_capture.jl
+++ b/test/log_capture.jl
@@ -10,7 +10,7 @@ using Test
 
     @testset "$log_display" for log_display in (:eager, :batched, :issues)
         # Need to run in a separate process to force --color=yes in CI.
-        cmd = addenv(`$(Base.julia_cmd()) --project=$PROJECT_PATH --color=yes $LOG_CAPTURE_TESTS_PATH`, "LOG_DISPLAY" => log_display)
+        cmd = addenv(`$(Base.julia_cmd()) --project=$PROJECT_PATH --color=yes $LOG_CAPTURE_TESTS_PATH`, "RETESTITEMS_LOGS" => log_display)
         p = run(pipeline(ignorestatus(cmd); stdout, stderr), wait=false)
         wait(p)
         @test success(p)


### PR DESCRIPTION
With `RETESTITEMS_LOGS` set to the appropriate string ("batched", "eager" or "issues").