### PR TITLE
Clearer terminology 'evaluate' -> 'run'

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReTestItems"
 uuid = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
-version = "1.19.0"
+version = "1.20.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -7,7 +7,7 @@ gettls(k, d) = get(task_local_storage(), k, d)
 """
     TestSetup(name, code)
 
-A module that a `TestItem` can require to be evaluated before that `TestItem` is run.
+A module that a `TestItem` can require to be run before that `TestItem` is run.
 Used for declaring code that multiple `TestItem`s rely on.
 Should only be created via the `@testsetup` macro.
 """
@@ -32,7 +32,7 @@ A module only used for tests, and which `@testitem`s can depend on.
 
 Useful for setup logic that is used across multiple test items.
 The setup will run once, before any `@testitem` that requires it is executed.
-If running with multiple processes, each test-setup with be evaluated once on each process.
+If running with multiple processes, each test-setup with be run once on each process.
 
 Each test-setup module will live for the lifetime of the tests.
 Mutable state should be avoided, since the order in which test items run is non-deterministic,
@@ -125,9 +125,9 @@ struct TestItem
     code::Any
     testsetups::Vector{TestSetup} # populated by runtests coordinator
     workerid::Base.RefValue{Int} # populated when the test item is scheduled
-    testsets::Vector{DefaultTestSet} # populated when the test item is finished evaluating
-    eval_number::Base.RefValue{Int} # to keep track of how many items have been evaluated so far
-    stats::Vector{PerfStats} # populated when the test item is finished evaluating
+    testsets::Vector{DefaultTestSet} # populated when the test item is finished running
+    eval_number::Base.RefValue{Int} # to keep track of how many items have been run so far
+    stats::Vector{PerfStats} # populated when the test item is finished running
     scheduled_for_evaluation::ScheduledForEvaluation # to keep track of whether the test item has been scheduled for evaluation
 end
 function TestItem(number, name, id, tags, default_imports, setups, retries, file, line, project_root, code)
@@ -182,7 +182,7 @@ A `@testitem` is wrapped into a module when run, so must import any additional p
         end
     end
 
-The test item's code is evaluated as top-level code in a new module, so it can include imports, define new structs or helper functions, and declare tests and testsets.
+The test item's code is run as top-level code in a new module, so it can include imports, define new structs or helper functions, and declare tests and testsets.
 
     @testitem "DoCoolStuff" begin
         function do_really_cool_stuff()

--- a/test/integrationtests.jl
+++ b/test/integrationtests.jl
@@ -573,7 +573,7 @@ end
     """,
     replace(c.output, r" on worker \d+" => ""))
 
-    # Since the test setup never succeeds it will be evaluated mutliple times. Here we test
+    # Since the test setup never succeeds it will be run mutliple times. Here we test
     # that we don't accumulate logs from all previous failed attempts (which would get
     # really spammy if the test setup is used by 100 test items).
     @test !occursin("""
@@ -610,7 +610,7 @@ end
     # Test the error is as expected
     err = only(non_passes(results))
     @test err.test_type == :nontest_error
-    @test err.value == string(ErrorException("Worker process aborted (signal=6) evaluating test item \"Abort\" (run=1)"))
+    @test err.value == string(ErrorException("Worker process aborted (signal=6) running test item \"Abort\" (run=1)"))
 end
 
 @testset "test retrying failing testitem" begin
@@ -665,7 +665,7 @@ end
     # Test the error is as expected
     err = only(non_passes(results))
     @test err.test_type == :nontest_error
-    @test err.value == string(ErrorException("Timed out after 4s evaluating test item \"Test item takes 60 seconds\" (run=1)"))
+    @test err.value == string(ErrorException("Timed out after 4s running test item \"Test item takes 60 seconds\" (run=1)"))
 end
 
 @testset "testitem timeout set via env variable" begin
@@ -682,7 +682,7 @@ end
     # Test the error is as expected
     err = only(non_passes(results))
     @test err.test_type == :nontest_error
-    @test err.value == string(ErrorException("Timed out after 4s evaluating test item \"Test item takes 60 seconds\" (run=1)"))
+    @test err.value == string(ErrorException("Timed out after 4s running test item \"Test item takes 60 seconds\" (run=1)"))
 end
 
 @testset "Error outside `@testitem`" begin

--- a/test/references/retry_tests_report_1worker.xml
+++ b/test/references/retry_tests_report_1worker.xml
@@ -244,7 +244,7 @@ No Captured Logs for test item "Has retries=1 and always fails" at test/testfile
 		<error message="Error during test at test/testfiles/_retry_tests.jl:54">Error in testset "Timeout always" on worker 72554:
 Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:54
   Got exception outside of a @test
-  Timed out after 5s evaluating test item "Timeout always" (run=1)
+  Timed out after 5s running test item "Timeout always" (run=1)
 Captured Logs for test item "Timeout always" at test/testfiles/_retry_tests.jl:54 on worker 72554
 
 signal (15): Terminated: 15
@@ -269,7 +269,7 @@ Allocations: 5231943 (Pool: 5229611; Big: 2332); GC: 30
 		<error message="Error during test at test/testfiles/_retry_tests.jl:54">Error in testset "Timeout always" on worker 72554:
 Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:54
   Got exception outside of a @test
-  Timed out after 5s evaluating test item "Timeout always" (run=2)
+  Timed out after 5s running test item "Timeout always" (run=2)
 Captured Logs for test item "Timeout always" at test/testfiles/_retry_tests.jl:54 on worker 72554
 
 signal (15): Terminated: 15
@@ -294,7 +294,7 @@ Allocations: 3068888 (Pool: 3067775; Big: 1113); GC: 3
 		<error message="Error during test at test/testfiles/_retry_tests.jl:54">Error in testset "Timeout always" on worker 72554:
 Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:54
   Got exception outside of a @test
-  Timed out after 5s evaluating test item "Timeout always" (run=3)
+  Timed out after 5s running test item "Timeout always" (run=3)
 Captured Logs for test item "Timeout always" at test/testfiles/_retry_tests.jl:54 on worker 72554
 
 signal (15): Terminated: 15
@@ -319,7 +319,7 @@ Allocations: 3068845 (Pool: 3067734; Big: 1111); GC: 3
 		<error message="Error during test at test/testfiles/_retry_tests.jl:64">Error in testset "Timeout first, pass after" on worker 72859:
 Error During Test at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_retry_tests.jl:64
   Got exception outside of a @test
-  Timed out after 5s evaluating test item "Timeout first, pass after" (run=1)
+  Timed out after 5s running test item "Timeout first, pass after" (run=1)
 Captured Logs for test item "Timeout first, pass after" at test/testfiles/_retry_tests.jl:64 on worker 72859
 
 signal (15): Terminated: 15


### PR DESCRIPTION
A user (@rbvermaa) found this log confusing:
```
┌ Error: Worker(pid=50335, terminated=true, termsignal=0) timed out evaluating test item "issue-2537" after 1800.0 seconds. Recording test error.
└ @ ReTestItems ~/.julia/packages/ReTestItems/IyiSd/src/ReTestItems.jl:534
```
so now we use clearer languange:
```
┌ Error: Worker(pid=50335, terminated=true, termsignal=0) timed out running test item "issue-2537" after 1800.0 seconds. Recording test error.
└ @ ReTestItems ~/.julia/packages/ReTestItems/IyiSd/src/ReTestItems.jl:534
```