### PR TITLE
Make worker `nthreads` log more specific

### DIFF
--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -391,7 +391,8 @@ function start_worker(proj_name, nworker_threads, worker_init_expr, ntestitems; 
         Test.TESTSET_PRINT_ENABLE[] = false
         const GLOBAL_TEST_CONTEXT = ReTestItems.TestContext($proj_name, $ntestitems)
         GLOBAL_TEST_CONTEXT.setups_evaled = ReTestItems.TestSetupModules()
-        @info "Starting test worker$($i) on pid = $(Libc.getpid()), with $(Threads.nthreads()) threads"
+        nthreads_str = $nworker_threads
+        @info "Starting test worker$($i) on pid = $(Libc.getpid()), with $nthreads_str threads"
         $(worker_init_expr.args...)
         nothing
     end)


### PR DESCRIPTION
- close https://github.com/JuliaTesting/ReTestItems.jl/issues/98

Before `runtests("test/testfiles/_happy_tests.jl"; nworkers=1, nworker_threads="2,1")` would log:
```julia
[ Info: Finished scanning for test items in 0.36 seconds. Scheduling 3 tests on pid 61125 with 1 worker processes and 2 threads per worker.
```
and with PR is will now log:
```julia
[ Info: Finished scanning for test items in 0.36 seconds. Scheduling 3 tests on pid 61125 with 1 worker processes and 2,1 threads per worker.
```
i.e.
```diff
- [ Info: ... with 1 worker processes and 2 threads per worker.
+ [ Info: ... with 1 worker processes and 2,1 threads per worker.