### PR TITLE
Allow `@testitem` to set its own timeout

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReTestItems"
 uuid = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
-version = "1.20.1"
+version = "1.21.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ runtests("frobble_tests.jl"; nworkers, worker_init_expr)
       runtests(MyPackage)
       ```
     - Pass to `runtests` any configuration you want your tests to run with, such as `retries`, `testitem_timeout`, `nworkers`, `nworker_threads`, `worker_init_expr`, `test_end_expr`.
-      See the `runtests` docstring for details.
+      See the [`runtests`](https://docs.juliahub.com/General/ReTestItems/stable/autodocs/#ReTestItems.runtests) docstring for details.
 
 ---
 

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -490,8 +490,6 @@ function manage_worker(
             worker = robust_start_worker(proj_name, nworker_threads, worker_init_expr, ntestitems)
         end
         testitem.workerid[] = worker.pid
-        # TODO: should the testitem's own timeout take precedence or should we just take the `max`?
-        # timeout = max(something(testitem.timeout, 0.0), default_timeout)
         timeout = something(testitem.timeout, default_timeout)
         fut = remote_eval(worker, :(ReTestItems.runtestitem($testitem, GLOBAL_TEST_CONTEXT; test_end_expr=$(QuoteNode(test_end_expr)), verbose_results=$verbose_results, logs=$(QuoteNode(logs)))))
         max_runs = 1 + max(retries, testitem.retries)

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -444,7 +444,7 @@ function record_timeout!(testitem, run_number::Int, timeout_s::Int)
         end
     end
     msg = "Timed out after $time_str running test item $(repr(testitem.name)) (run=$run_number)"
-    record_test_error!(testitem, msg, timeout_limit)
+    record_test_error!(testitem, msg, timeout_s)
 end
 
 function record_worker_terminated!(testitem, worker::Worker, run_number::Int)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -119,7 +119,7 @@ struct TestItem
     default_imports::Bool
     setups::Vector{Symbol}
     retries::Int
-    timeout::Union{Float64,Nothing} # in seconds
+    timeout::Union{Int,Nothing} # in seconds
     file::String
     line::Int
     project_root::String
@@ -259,9 +259,10 @@ macro testitem(nm, exs...)
                 retries = ex.args[2]
                 @assert retries isa Integer "`default_imports` keyword must be passed an `Integer`"
             elseif kw == :timeout
-                timeout = ex.args[2]
-                @assert timeout isa Real "`timeout` keyword must be passed a `Real`"
-                @assert timeout > 0 "`timeout` keyword must be passed a positive number. Got `timeout=$timeout`"
+                t = ex.args[2]
+                @assert t isa Real "`timeout` keyword must be passed a `Real`"
+                @assert t > 0 "`timeout` keyword must be passed a positive number. Got `timeout=$timeout`"
+                timout = ceil(Int, t)
             elseif kw == :_id
                 _id = ex.args[2]
                 # This will always be written to the JUnit XML as a String, require the user

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -119,6 +119,7 @@ struct TestItem
     default_imports::Bool
     setups::Vector{Symbol}
     retries::Int
+    timeout::Union{Float64,Nothing} # in seconds
     file::String
     line::Int
     project_root::String
@@ -130,10 +131,10 @@ struct TestItem
     stats::Vector{PerfStats} # populated when the test item is finished running
     scheduled_for_evaluation::ScheduledForEvaluation # to keep track of whether the test item has been scheduled for evaluation
 end
-function TestItem(number, name, id, tags, default_imports, setups, retries, file, line, project_root, code)
+function TestItem(number, name, id, tags, default_imports, setups, retries, timeout, file, line, project_root, code)
     _id = @something(id, repr(hash(name, hash(relpath(file, project_root)))))
     return TestItem(
-        number, name, _id, tags, default_imports, setups, retries, file, line, project_root, code,
+        number, name, _id, tags, default_imports, setups, retries, timeout, file, line, project_root, code,
         TestSetup[],
         Ref{Int}(0),
         DefaultTestSet[],
@@ -219,10 +220,19 @@ If a `@testitem` passes on retry, then it will be recorded as passing in the tes
     @testitem "Flaky test" retries=1 begin
         @test rand() < 1e-4
     end
+
+If a `@testitem` should be aborted after a certain period of time, e.g. the test is known
+to occassionally hang, then you can set a timeout (in seconds) by passing the `timeout` keyword.
+Note that `timeout` currently only works when tests are run with multiple workers.
+
+    @testitem "Sometimes too slow" timeout=10 begin
+        @test sleep(rand(1:100))
+    end
 """
 macro testitem(nm, exs...)
     default_imports = true
     retries = 0
+    timeout = nothing
     tags = Symbol[]
     setup = Any[]
     _id = nothing
@@ -248,6 +258,10 @@ macro testitem(nm, exs...)
             elseif kw == :retries
                 retries = ex.args[2]
                 @assert retries isa Integer "`default_imports` keyword must be passed an `Integer`"
+            elseif kw == :timeout
+                timeout = ex.args[2]
+                @assert timeout isa Real "`timeout` keyword must be passed a `Real`"
+                @assert timeout > 0 "`timeout` keyword must be passed a positive number. Got `timeout=$timeout`"
             elseif kw == :_id
                 _id = ex.args[2]
                 # This will always be written to the JUnit XML as a String, require the user
@@ -272,7 +286,7 @@ macro testitem(nm, exs...)
     ti = gensym(:ti)
     esc(quote
         let $ti = $TestItem(
-            $Ref(0), $nm, $_id, $tags, $default_imports, $setup, $retries,
+            $Ref(0), $nm, $_id, $tags, $default_imports, $setup, $retries, $timeout,
             $String($_source.file), $_source.line,
             $gettls(:__RE_TEST_PROJECT__, "."),
             $q,

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -262,7 +262,7 @@ macro testitem(nm, exs...)
                 t = ex.args[2]
                 @assert t isa Real "`timeout` keyword must be passed a `Real`"
                 @assert t > 0 "`timeout` keyword must be passed a positive number. Got `timeout=$timeout`"
-                timout = ceil(Int, t)
+                timeout = ceil(Int, t)
             elseif kw == :_id
                 _id = ex.args[2]
                 # This will always be written to the JUnit XML as a String, require the user

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -261,7 +261,7 @@ macro testitem(nm, exs...)
             elseif kw == :timeout
                 t = ex.args[2]
                 @assert t isa Real "`timeout` keyword must be passed a `Real`"
-                @assert t > 0 "`timeout` keyword must be passed a positive number. Got `timeout=$timeout`"
+                @assert t > 0 "`timeout` keyword must be passed a positive number. Got `timeout=$t`"
                 timeout = ceil(Int, t)
             elseif kw == :_id
                 _id = ex.args[2]

--- a/test/internals.jl
+++ b/test/internals.jl
@@ -169,7 +169,7 @@ end # `include_testfiles!` testset
 @testset "report_empty_testsets" begin
     using ReTestItems: TestItem, report_empty_testsets, PerfStats, ScheduledForEvaluation
     using Test: DefaultTestSet, Fail, Error
-    ti = TestItem(Ref(42), "Dummy TestItem", "DummyID", [], false, [], 0, "source/path", 42, ".", nothing)
+    ti = TestItem(Ref(42), "Dummy TestItem", "DummyID", [], false, [], 0, nothing, "source/path", 42, ".", nothing)
 
     ts = DefaultTestSet("Empty testset")
     report_empty_testsets(ti, ts)

--- a/test/log_capture.jl
+++ b/test/log_capture.jl
@@ -33,7 +33,7 @@ end
 @testset "log capture -- reporting" begin
     setup1 = @testsetup module TheTestSetup1 end
     setup2 = @testsetup module TheTestSetup2 end
-    ti = TestItem(Ref(42), "TheTestItem", "ID007", [], false, [], 0, "source/path", 42, ".", nothing)
+    ti = TestItem(Ref(42), "TheTestItem", "ID007", [], false, [], 0, nothing, "source/path", 42, ".", nothing)
     push!(ti.testsetups, setup1)
     push!(ti.testsetups, setup2)
     push!(ti.testsets, Test.DefaultTestSet("dummy"))

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -276,14 +276,15 @@ end
         ti = @testitem "TI" timeout=1 begin
             @test true
         end
-        @test ti.timeout isa Float64
+        @test ti.timeout isa Int
         @test ti.timeout == 1
 
+        # We round up to the nearest second.
         ti = @testitem "TI" timeout=1.1 begin
             @test true
         end
-        @test ti.timeout isa Float64
-        @test ti.timeout == 1.1
+        @test ti.timeout isa Int
+        @test ti.timeout == 2
 
         ti = @testitem "TI" begin
             @test true

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -252,6 +252,46 @@ end
     @test_throws expected (@eval @testitem("five", _id=hash("five"), _run=false, begin end))
 end
 
+# Here we are just testing how the `timeout` keyword is parsed.
+# The actual timeout functionality is tested in `integrationtests.jl`,
+# because we need to call `runtests` with multiple workers to test timeout functionality.
+# See https://github.com/JuliaTesting/ReTestItems.jl/issues/87
+@testset "testitem `timeout` keyword" begin
+    expected(t) = "`timeout` keyword must be passed a positive number. Got `timeout=$t`"
+    for t in (0, -1.1)
+        @test_throws expected(t) (
+            @eval @testitem "Bad" timeout=$t begin
+                @test true
+            end
+        )
+    end
+
+    @test_throws "`timeout` keyword must be passed a `Real`" (
+        @eval @testitem "Bad" timeout=1im begin
+            @test true
+        end
+    )
+
+    no_run() do
+        ti = @testitem "TI" timeout=1 begin
+            @test true
+        end
+        @test ti.timeout isa Float64
+        @test ti.timeout == 1
+
+        ti = @testitem "TI" timeout=1.1 begin
+            @test true
+        end
+        @test ti.timeout isa Float64
+        @test ti.timeout == 1.1
+
+        ti = @testitem "TI" begin
+            @test true
+        end
+        @test ti.timeout == nothing
+    end
+end
+
 
 #=
 NOTE:

--- a/test/testfiles/_timeout2_tests.jl
+++ b/test/testfiles/_timeout2_tests.jl
@@ -1,0 +1,4 @@
+@testitem "Sets timeout=6" timeout=6 begin
+    sleep(10)
+    @test true
+end


### PR DESCRIPTION
- close https://github.com/JuliaTesting/ReTestItems.jl/issues/13
- an `@testitem` can set its own timeout (in seconds) via the `timeout` keyword, like `@testitem "foo" timeout=600`
- this value takes precedence over the `testitem_timeout` passed to `runtests(...)` (i.e. this PR makes `testitem_timeout` be a "default" timeout value that can be overridden per testitem.)
  - The alternative would be to take the `max` of the two values, which is what we do for `retries` (so that inconsistency is perhaps a little unfortunate).
  - But giving the `@testitem`'s own `timeout=...` value precedence allows a `@testitem` to set a _lower_ limit than the default, which is useful for tests that should go fast but are at risk of blowup.
