### PR TITLE
[RFC] Allow `timeout` to take an expression like `60*2`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReTestItems"
 uuid = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
-version = "1.23.0"
+version = "1.24.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -277,10 +277,14 @@ macro testitem(nm, exs...)
                 # since @testitem should only ever run at the top-level. But we still eval in a
                 # new anonymous module, because we don't want to risk polluting the global scope,
                 # and nothing from global scope should need to be available here.
-                t = ex.args[2] isa Expr ? Core.eval(Module(), ex.args[2]) : ex.args[2]
-                @assert t isa Real "`timeout` keyword must be passed a `Real`, got `timeout=$t`"
-                @assert t > 0 "`timeout` keyword must be passed a positive number. Got `timeout=$t`"
-                timeout = ceil(Int, t)
+                t = ex.args[2] isa Union{Expr,Symbol} ? Core.eval(Module(), ex.args[2]) : ex.args[2]
+                @assert t isa Union{Nothing,Real} "`timeout` keyword must be passed `nothing` or a `Real`, got `timeout=$t`"
+                if isnothing(t)
+                    timeout = nothing
+                else
+                    @assert t > 0 "`timeout` keyword must be passed a positive number. Got `timeout=$t`"
+                    timeout = ceil(Int, t)
+                end
             elseif kw == :skip
                 skip = ex.args[2]
                 # If the `Expr` doesn't evaluate to a Bool, throws at runtime.

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -295,6 +295,16 @@ end
             @test true
         end
         @test ti.timeout == nothing
+
+        ti = @testitem "TI" timeout=nothing begin
+            @test true
+        end
+        @test ti.timeout == nothing
+
+        ti = @testitem "TI" timeout=(1+2; nothing) begin
+            @test true
+        end
+        @test ti.timeout == nothing
     end
 end
 

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -278,6 +278,12 @@ end
         @test ti.timeout isa Int
         @test ti.timeout == 1
 
+        ti = @testitem "TI" timeout=1*2 begin
+            @test true
+        end
+        @test ti.timeout isa Int
+        @test ti.timeout == 2
+
         # We round up to the nearest second.
         ti = @testitem "TI" timeout=1.1 begin
             @test true


### PR DESCRIPTION
Because
```julia
@testitem "TI" timeout=60*15 begin
    ...
end
```
is a lot clearer than
```julia
@testitem "TI" timeout=900 begin
    ...
end
```