### PR TITLE
Add `failfast` option

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReTestItems"
 uuid = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
-version = "1.27.0"
+version = "1.28.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/README.md
+++ b/README.md
@@ -118,10 +118,13 @@ Note ReTestItems.jl uses distributed parallelism, not multi-threading, to run te
 
 #### Stopping tests early
 
-You can set `runtests` to stop on the first test failure by passing `failfast=true`.
+You can set `runtests` to stop on the first test-item failure by passing `failfast=true`.
 Note this prevents any new test-items starting to run after the first test failure, but
 tests that were already running on another worker in parallel with the failing test will complete and appear in the test report.
 Tests that were not run will not appear in the test report.
+
+If you want individual test-items to stop on the first failure, you can pass `testitem_failfast=true` to `runtests`.
+
 
 ## Writing tests
 
@@ -200,6 +203,19 @@ The `skip` keyword allows you to define the condition under which a test needs t
 for example if it can only be run on a certain platform.
 See [filtering tests](#filtering-tests) for controlling which tests run in a particular `runtests` call.
 
+#### Failing early
+
+Each test-item can control whether or not it stops on the first failure using the `failfast` keyword.
+
+```julia
+@testitem "stops on first failure" failfast=true begin
+    @test 1 + 1 == 3
+    @test 2 * 2 == 4
+end
+```
+
+If a test-items set the `failfast` then that value takes precedence over the `testitem_failfast` keyword passed to `runtests`.
+
 #### Post-testitem hook
 
 If there is something that should be checked after every single `@testitem`, then it's possible to pass an expression to `runtests` using the `test_end_expr` keyword.
@@ -261,7 +277,7 @@ runtests("frobble_tests.jl"; nworkers, worker_init_expr)
       using ReTestItems, MyPackage
       runtests(MyPackage)
       ```
-    - Pass to `runtests` any configuration you want your tests to run with, such as `retries`, `testitem_timeout`, `nworkers`, `nworker_threads`, `worker_init_expr`, `test_end_expr`.
+    - Pass to `runtests` any configuration you want your tests to run with, such as `retries`, `failfast`, `testitem_failfast`, `testitem_timeout`, `nworkers`, `nworker_threads`, `worker_init_expr`, `test_end_expr`.
       See the [`runtests`](https://docs.juliahub.com/General/ReTestItems/stable/autodocs/#ReTestItems.runtests) docstring for details.
 
 ---

--- a/README.md
+++ b/README.md
@@ -119,11 +119,15 @@ Note ReTestItems.jl uses distributed parallelism, not multi-threading, to run te
 #### Stopping tests early
 
 You can set `runtests` to stop on the first test-item failure by passing `failfast=true`.
-Note this prevents any new test-items starting to run after the first test failure, but
-tests that were already running on another worker in parallel with the failing test will complete and appear in the test report.
-Tests that were not run will not appear in the test report.
 
-If you want individual test-items to stop on the first failure, you can pass `testitem_failfast=true` to `runtests`.
+> [!NOTE]
+> Note `failfast` prevents any new test-items starting to run after the first test-item failure, but
+> test-itemss that were already running on another worker in parallel with the failing test will complete and appear in the test report.
+> Tests that were not run will not appear in the test report.
+>
+> This may be improved in a future version of ReTestItems.jl, so that even test-items running in parallel are stopped on when one test-item fails
+
+If you want individual test-items to stop on their first test failure, you can pass `testitem_failfast=true` to `runtests`.
 
 
 ## Writing tests

--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ Filtering by `name` and `tags` can be combined to run only test-items that match
 julia> runtests("test/Database/"; tags=:regression, name=r"^issue")
 ```
 
-
 #### Running tests in parallel
 
 You can run tests in parallel on multiple worker processes using the `nworkers` keyword.
@@ -116,6 +115,13 @@ thread
 threadpools](https://docs.julialang.org/en/v1/manual/multi-threading/#man-threadpools)).
 
 Note ReTestItems.jl uses distributed parallelism, not multi-threading, to run test-items in parallel.
+
+#### Stopping tests early
+
+You can set `runtests` to stop on the first test failure by passing `failfast=true`.
+Note this prevents any new test-items starting to run after the first test failure, but
+tests that were already running on another worker in parallel with the failing test will complete and appear in the test report.
+Tests that were not run will not appear in the test report.
 
 ## Writing tests
 

--- a/README.md
+++ b/README.md
@@ -120,14 +120,15 @@ Note ReTestItems.jl uses distributed parallelism, not multi-threading, to run te
 
 You can set `runtests` to stop on the first test-item failure by passing `failfast=true`.
 
+
 > [!NOTE]
 > Note `failfast` prevents any new test-items starting to run after the first test-item failure, but
-> test-itemss that were already running on another worker in parallel with the failing test will complete and appear in the test report.
+> test-items that were already running on another worker in parallel with the failing test will complete and appear in the test report.
 > Tests that were not run will not appear in the test report.
 >
-> This may be improved in a future version of ReTestItems.jl, so that even test-items running in parallel are stopped on when one test-item fails
+> This may be improved in a future version of ReTestItems.jl, so that all test-items running in parallel are stopped on when one test-item fails
 
-If you want individual test-items to stop on their first test failure, you can pass `testitem_failfast=true` to `runtests`.
+If you want individual test-items to stop on their first test failure, but not stop the whole `runtests` early, you can instead pass just `testitem_failfast=true` to `runtests`.
 
 
 ## Writing tests

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -208,6 +208,7 @@ will be run.
 - `failfast::Bool=false`: If true, no additional testitems are run after a testitem fails.
   A testitem is considered to have failed if it does not pass after retries.
   Note that testitems already running on other workers in parallel with the failing testitem are allowed to complete.
+  Can also be set using the `RETESTITEMS_FAILFAST` environment variable.
 """
 function runtests end
 
@@ -241,7 +242,7 @@ function runtests(
     validate_paths::Bool=parse(Bool, get(ENV, "RETESTITEMS_VALIDATE_PATHS", "false")),
     timeout_profile_wait::Real=parse(Int, get(ENV, "RETESTITEMS_TIMEOUT_PROFILE_WAIT", "0")),
     gc_between_testitems::Bool=parse(Bool, get(ENV, "RETESTITEMS_GC_BETWEEN_TESTITEMS", string(nworkers > 1))),
-    failfast::Bool=false,
+    failfast::Bool=parse(Bool, get(ENV, "RETESTITEMS_FAILFAST", "false")),
 )
     nworker_threads = _validated_nworker_threads(nworker_threads)
     paths′ = _validated_paths(paths, validate_paths)

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -220,13 +220,14 @@ will be run.
    for more information on triggered profiles. Note you can use `worker_init_expr` to tweak the profile settings on workers.
 - `failfast::Bool=false`: If true, no additional testitems are run after a testitem fails.
   A testitem is considered to have failed if it does not pass after retries.
-  Note that testitems already running on other workers in parallel with the failing testitem are allowed to complete.
+  Note that in the current implementation testitems already running on other workers in parallel with the failing testitem are allowed to complete,
+  but this may be improved in a future version.
   Can also be set using the `RETESTITEMS_FAILFAST` environment variable.
 - `testitem_failfast::Bool=failfast`: If true, a testitem stops as soon as there is a test failure or error.
   Can also be set using the `RETESTITEMS_TESTITEM_FAILFAST` environment variable.
   Defaults to the value passed to the `failfast` keyword.
   If a `@testitem` sets its own `failfast` keyword, then that takes precedence.
-  The `testitem_failfast` keyword only takes effect in Julia v1.9+ and is ignored in earlier Julia versions.
+  Note that the `testitem_failfast` keyword only takes effect in Julia v1.9+ and is ignored in earlier Julia versions.
 """
 function runtests end
 

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -222,11 +222,11 @@ will be run.
   A testitem is considered to have failed if it does not pass after retries.
   Note that testitems already running on other workers in parallel with the failing testitem are allowed to complete.
   Can also be set using the `RETESTITEMS_FAILFAST` environment variable.
-- `testitem_failfast::Bool=false`: If true, a testitem stops as soon as there is a test failure or error.
+- `testitem_failfast::Bool=failfast`: If true, a testitem stops as soon as there is a test failure or error.
   Can also be set using the `RETESTITEMS_TESTITEM_FAILFAST` environment variable.
+  Defaults to the value passed to the `failfast` keyword.
   If a `@testitem` sets its own `failfast` keyword, then that takes precedence.
-  The `testitem_failfast` keyword only takes effect in Julia v1.9+ and is ignored in earlier
-  Julia versions.
+  The `testitem_failfast` keyword only takes effect in Julia v1.9+ and is ignored in earlier Julia versions.
 """
 function runtests end
 
@@ -261,7 +261,7 @@ function runtests(
     timeout_profile_wait::Real=parse(Int, get(ENV, "RETESTITEMS_TIMEOUT_PROFILE_WAIT", "0")),
     gc_between_testitems::Bool=parse(Bool, get(ENV, "RETESTITEMS_GC_BETWEEN_TESTITEMS", string(nworkers > 1))),
     failfast::Bool=parse(Bool, get(ENV, "RETESTITEMS_FAILFAST", "false")),
-    testitem_failfast::Bool=parse(Bool, get(ENV, "RETESTITEMS_TESTITEM_FAILFAST", "false")),
+    testitem_failfast::Bool=parse(Bool, get(ENV, "RETESTITEMS_TESTITEM_FAILFAST", string(failfast))),
 )
     nworker_threads = _validated_nworker_threads(nworker_threads)
     paths′ = _validated_paths(paths, validate_paths)

--- a/src/log_capture.jl
+++ b/src/log_capture.jl
@@ -304,7 +304,7 @@ end
 function print_failfast_summary(t::TestItems)
     io = DEFAULT_STDOUT[]
     printstyled(io, "FailFast: "; bold=true, color=Base.warn_color())
-    println(io, "$(t.count)/$(length(t.testitems)) tests were run.")
+    println(io, "$(t.count)/$(length(t.testitems)) test items were run.")
     return nothing
 end
 

--- a/src/log_capture.jl
+++ b/src/log_capture.jl
@@ -12,8 +12,8 @@ function save_current_stdio()
     DEFAULT_LOGGER[] = Base.CoreLogging._global_logstate.logger
 end
 
-# A lock that helps to stagger prints to DEFAULT_STDOUT, used in `print_errors_and_captured_logs`
-# which is called by multiple tasks on the coordinator
+# A lock that helps to stagger prints to DEFAULT_STDOUT, used in functions that print and
+# are called by multiple tasks on the coordinator, e.g. `print_errors_and_captured_logs`
 const LogCaptureLock = ReentrantLock()
 macro loglock(expr)
     return :(@lock LogCaptureLock $(esc(expr)))
@@ -286,6 +286,26 @@ function log_testitem_done(ti::TestItem, ntestitems=0)
     print_time(io; x.elapsedtime, x.bytes, x.gctime, x.allocs, x.compile_time, x.recompile_time)
     println(io)
     write(DEFAULT_STDOUT[], take!(io.io))
+end
+
+# So that the user is warned that we're cancelling the rest of the run.
+# Use loglock here as this is called when multiple tasks are running tests and printing output.
+function print_failfast_cancellation(ti::TestItem)
+    io = IOContext(IOBuffer(), :color => get(DEFAULT_STDOUT[], :color, false)::Bool)
+    printstyled(io, "FailFast: "; bold=true, color=Base.warn_color())
+    println(io, "Test item $(repr(ti.name)) at $(_file_info(ti)) failed. Cancelling tests.")
+    @loglock write(DEFAULT_STDOUT[], take!(io.io))
+    return nothing
+end
+
+# So that the user is warned that not all tests were run.
+# We don't use loglock here, because this is only called once on the coordinator after all
+# tasks running tests have stopped and we're printing the final test report.
+function print_failfast_summary(t::TestItems)
+    io = DEFAULT_STDOUT[]
+    printstyled(io, "FailFast: "; bold=true, color=Base.warn_color())
+    println(io, "$(t.count)/$(length(t.testitems)) tests were run.")
+    return nothing
 end
 
 function report_empty_testsets(ti::TestItem, ts::DefaultTestSet)

--- a/src/log_capture.jl
+++ b/src/log_capture.jl
@@ -279,11 +279,12 @@ function log_testitem_start(ti::TestItem, ntestitems=0)
     write(DEFAULT_STDOUT[], take!(io.io))
 end
 
-function log_testitem_done(ti::TestItem, ntestitems=0)
+function log_testitem_done(ti::TestItem, ntestitems=0; failedfast::Bool=false)
     io = IOContext(IOBuffer(), :color => get(DEFAULT_STDOUT[], :color, false)::Bool)
     print_state(io, "DONE", ti, ntestitems)
     x = last(ti.stats) # always print stats for most recent run
     print_time(io; x.elapsedtime, x.bytes, x.gctime, x.allocs, x.compile_time, x.recompile_time)
+    failedfast && printstyled(io, " [Failed Fast]"; color=Base.warn_color())
     println(io)
     write(DEFAULT_STDOUT[], take!(io.io))
 end
@@ -292,7 +293,7 @@ end
 # Use loglock here as this is called when multiple tasks are running tests and printing output.
 function print_failfast_cancellation(ti::TestItem)
     io = IOContext(IOBuffer(), :color => get(DEFAULT_STDOUT[], :color, false)::Bool)
-    printstyled(io, "FailFast: "; bold=true, color=Base.warn_color())
+    printstyled(io, "[ Fail Fast: "; bold=true, color=Base.warn_color())
     println(io, "Test item $(repr(ti.name)) at $(_file_info(ti)) failed. Cancelling tests.")
     @loglock write(DEFAULT_STDOUT[], take!(io.io))
     return nothing
@@ -303,7 +304,7 @@ end
 # tasks running tests have stopped and we're printing the final test report.
 function print_failfast_summary(t::TestItems)
     io = DEFAULT_STDOUT[]
-    printstyled(io, "FailFast: "; bold=true, color=Base.warn_color())
+    printstyled(io, "[ Fail Fast: "; bold=true, color=Base.warn_color())
     println(io, "$(t.count)/$(length(t.testitems)) test items were run.")
     return nothing
 end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -242,6 +242,14 @@ expression that returns a `Bool` to determine if the testitem should be skipped.
 
 The `skip` expression is run in its own module, just like a test-item.
 No code inside a `@testitem` is run when a test-item is skipped.
+
+If a `@testitem` should stop running on the first test failure, then you can set the `failfast` keyword.
+
+    @testitem "stop early" failfast=true begin
+        @test false
+        @test true
+        @test error("oops")
+    end
 """
 macro testitem(nm, exs...)
     default_imports = true

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -121,6 +121,7 @@ struct TestItem
     retries::Int
     timeout::Union{Int,Nothing} # in seconds
     skip::Union{Bool,Expr}
+    failfast::Union{Bool,Nothing}
     file::String
     line::Int
     project_root::String
@@ -132,10 +133,10 @@ struct TestItem
     stats::Vector{PerfStats} # populated when the test item is finished running
     scheduled_for_evaluation::ScheduledForEvaluation # to keep track of whether the test item has been scheduled for evaluation
 end
-function TestItem(number, name, id, tags, default_imports, setups, retries, timeout, skip, file, line, project_root, code)
+function TestItem(number, name, id, tags, default_imports, setups, retries, timeout, skip, failfast, file, line, project_root, code)
     _id = @something(id, repr(hash(name, hash(relpath(file, project_root)))))
     return TestItem(
-        number, name, _id, tags, default_imports, setups, retries, timeout, skip, file, line, project_root, code,
+        number, name, _id, tags, default_imports, setups, retries, timeout, skip, failfast, file, line, project_root, code,
         TestSetup[],
         Ref{Int}(0),
         DefaultTestSet[],
@@ -249,6 +250,7 @@ macro testitem(nm, exs...)
     tags = Symbol[]
     setup = Any[]
     skip = false
+    failfast = nothing
     _id = nothing
     _run = true  # useful for testing `@testitem` itself
     _source = QuoteNode(__source__)
@@ -284,6 +286,9 @@ macro testitem(nm, exs...)
                 skip = ex.args[2]
                 # If the `Expr` doesn't evaluate to a Bool, throws at runtime.
                 @assert skip isa Union{Bool,Expr} "`skip` keyword must be passed a `Bool`"
+            elseif kw == :failfast
+                failfast = ex.args[2]
+                @assert failfast isa Bool "`failfast` keyword must be passed a `Bool`. Got `failfast=$failfast`"
             elseif kw == :_id
                 _id = ex.args[2]
                 # This will always be written to the JUnit XML as a String, require the user
@@ -309,7 +314,7 @@ macro testitem(nm, exs...)
     ti = gensym(:ti)
     esc(quote
         let $ti = $TestItem(
-            $Ref(0), $nm, $_id, $tags, $default_imports, $setup, $retries, $timeout, $skip,
+            $Ref(0), $nm, $_id, $tags, $default_imports, $setup, $retries, $timeout, $skip, $failfast,
             $String($_source.file), $_source.line,
             $gettls(:__RE_TEST_PROJECT__, "."),
             $q,

--- a/src/testcontext.jl
+++ b/src/testcontext.jl
@@ -104,6 +104,7 @@ end
 TestItems(graph) = TestItems(graph, TestItem[])
 TestItems(graph, testitems) = TestItems(graph, testitems, Cancellation(), 0)
 cancel(t::TestItems) = cancel(t.cancellation)
+is_cancelled(t::TestItems) = check(t.cancellation)
 
 ###
 ### record results
@@ -174,7 +175,7 @@ end
 
 # i is the index of the last test item that was run
 function next_testitem(ti::TestItems, i::Int)
-    check(ti.cancellation) && return nothing
+    is_cancelled(ti) && return nothing
     len = length(ti.testitems)
     n = len
     while n > 0

--- a/test/integrationtests.jl
+++ b/test/integrationtests.jl
@@ -1310,7 +1310,7 @@ end
     @test !success(p)
 end
 
-@testset "failfast" begin
+@testset "runtests `failfast` keyword" begin
     using IOCapture
     # Each file has 3 testitems, with the second test item "bad" failing in some way.
     @testset "$case" for (case, filename) in (

--- a/test/integrationtests.jl
+++ b/test/integrationtests.jl
@@ -1398,4 +1398,20 @@ if VERSION >= v"1.9"
     end
 end
 
+# In earlier versions of ReTestItems, if the testitem threw an error (outside of an `@test`)
+# we would report the time taken as `"0 secs"` in the DONE log message, because we didn't
+# have any timing info in `@timed_wth_compilation`. Now we should fallback to the timing
+# info in the testset, which for this tests should be non-zero.
+@testset "DONE time reported when testitem throws" begin
+    using IOCapture
+    file = joinpath(TEST_FILES_DIR, "_error_test.jl")
+    c = IOCapture.capture() do
+        encased_testset(()->runtests(file))
+    end
+    expected = r"DONE  \(1/1\) test item \"Test that throws outside of a @test\" (\d.\d) secs"
+    m = match(expected, c.output)
+    @test m != nothing
+    @test parse(Float64, only(m)) > 0
+end
+
 end # integrationtests.jl testset

--- a/test/integrationtests.jl
+++ b/test/integrationtests.jl
@@ -682,7 +682,7 @@ end
     tmpdir = joinpath("/tmp", "JL_RETESTITEMS_TEST_TMPDIR")
     # must run with `testitem_timeout < 20` for test to timeout as expected.
     # and must run with `nworkers > 0` for retries to be supported.
-    results = encased_testset(()->runtests(file; nworkers=1, retries=2, testitem_timeout=3))
+    results = encased_testset(()->runtests(file; nworkers=1, retries=2, testitem_timeout=5))
     # Test we _ran_ each test-item the expected number of times
     read_count(x) = parse(Int, read(x, String))
     # Passes on second attempt, so only need to retry once.
@@ -1319,7 +1319,7 @@ end
         :timeout => "_failfast_timeout_tests.jl",
         :crash   => "_failfast_crash_tests.jl",
     )
-        testitem_timeout = 3
+        testitem_timeout = 5
         file = joinpath(TEST_FILES_DIR, filename)
         # For 0 or 1 workers, we expect to fail on the second testitem out of 3.
         # If running with 3 workers, then all 3 testitems will be running in parallel,
@@ -1343,7 +1343,7 @@ end
                 @test n_passed(results) == 1
             end
             # @show c.output
-            @test contains(c.output, "Retrying")
+            @test contains(c.output, "Retrying")  # check retries are happening
             @test count(r"FailFast:", c.output) == 2
             msg = "FailFast: Test item \"bad\" at test/testfiles/$filename:4 failed. Cancelling tests."
             @test contains(c.output, msg)

--- a/test/integrationtests.jl
+++ b/test/integrationtests.jl
@@ -732,7 +732,7 @@ end
     c = IOCapture.capture() do
         encased_testset(() -> runtests(file, nworkers=0, failfast=true))
     end
-    @test contains(c.output, "FailFast: 2/3 test items were run.")
+    @test contains(c.output, "[ Fail Fast: 2/3 test items were run.")
 end
 
 
@@ -1344,13 +1344,13 @@ end
             end
             # @show c.output
             @test contains(c.output, "Retrying")  # check retries are happening
-            @test count(r"FailFast:", c.output) == 2
-            msg = "FailFast: Test item \"bad\" at test/testfiles/$filename:4 failed. Cancelling tests."
+            @test count(r"\[ Fail Fast:", c.output) == 2
+            msg = "[ Fail Fast: Test item \"bad\" at test/testfiles/$filename:4 failed. Cancelling tests."
             @test contains(c.output, msg)
             if nworkers == 3
-                @test contains(c.output, "FailFast: 3/3 test items were run.")
+                @test contains(c.output, "[ Fail Fast: 3/3 test items were run.")
             else
-                @test contains(c.output, "FailFast: 2/3 test items were run.")
+                @test contains(c.output, "[ Fail Fast: 2/3 test items were run.")
             end
         end # nworkers
     end # case
@@ -1365,8 +1365,8 @@ end
         @test n_tests(results) == 2
         @test n_passed(results) == 0
         @test count(r"Cancelling tests.", c.output) == 1
-        @test count(r"FailFast:", c.output) == 2
-        @test contains(c.output, "FailFast: 2/3 test items were run.")
+        @test count(r"\[ Fail Fast:", c.output) == 2
+        @test contains(c.output, "[ Fail Fast: 2/3 test items were run.")
     end
     # test setting `failfast` via environment variable
     @testset "ENV var" begin
@@ -1379,7 +1379,7 @@ end
         results = c.value
         @test n_tests(results) == 2
         @test n_passed(results) == 1
-        @test contains(c.output, "FailFast: 2/3 test items were run.")
+        @test contains(c.output, "[ Fail Fast: 2/3 test items were run.")
     end
 end
 

--- a/test/integrationtests.jl
+++ b/test/integrationtests.jl
@@ -1383,5 +1383,19 @@ end
     end
 end
 
+# In Julia v1.9, `@testset` supports its own `failfast` keyword
+# See https://github.com/JuliaLang/julia/commit/88def1afe16acdfe41b15dc956742359d837ce04
+# Test that we are not rethrowing a `Test.FailFastError`.
+if VERSION >= v"1.9"
+    @testset "Handle `@testset failfast=true`" begin
+        file = joinpath(TEST_FILES_DIR, "_testset_failfast_tests.jl")
+        results = encased_testset(()->runtests(file))
+        # We should only see that a single test-item ran and had a single test failure,
+        # we should not see a `Test.FailFastError` error.
+        @test n_tests(results) == 1
+        @test length(non_passes(results)) == 1
+        @test length(errors(results)) == 0
+    end
+end
 
 end # integrationtests.jl testset

--- a/test/internals.jl
+++ b/test/internals.jl
@@ -169,7 +169,7 @@ end # `include_testfiles!` testset
 @testset "report_empty_testsets" begin
     using ReTestItems: TestItem, report_empty_testsets, PerfStats, ScheduledForEvaluation
     using Test: DefaultTestSet, Fail, Error
-    ti = TestItem(Ref(42), "Dummy TestItem", "DummyID", [], false, [], 0, nothing, false, "source/path", 42, ".", nothing)
+    ti = TestItem(Ref(42), "Dummy TestItem", "DummyID", [], false, [], 0, nothing, false, nothing, "source/path", 42, ".", nothing)
 
     ts = DefaultTestSet("Empty testset")
     report_empty_testsets(ti, ts)

--- a/test/internals.jl
+++ b/test/internals.jl
@@ -12,7 +12,7 @@ using ReTestItems
     for nworkers in 1:10
         for nitems in 1:10
             testitems = [@testitem("ti-$i", _run=false, begin end) for i in 1:nitems]
-            starts = get_starting_testitems(TestItems(graph, testitems, 0), nworkers)
+            starts = get_starting_testitems(TestItems(graph, testitems), nworkers)
             startitems = [x for x in starts if !isnothing(x)]
             @test length(starts) == nworkers
             @test length(startitems) == min(nworkers, nitems)

--- a/test/log_capture.jl
+++ b/test/log_capture.jl
@@ -33,7 +33,7 @@ end
 @testset "log capture -- reporting" begin
     setup1 = @testsetup module TheTestSetup1 end
     setup2 = @testsetup module TheTestSetup2 end
-    ti = TestItem(Ref(42), "TheTestItem", "ID007", [], false, [], 0, nothing, false, "source/path", 42, ".", nothing)
+    ti = TestItem(Ref(42), "TheTestItem", "ID007", [], false, [], 0, nothing, false, nothing, "source/path", 42, ".", nothing)
     push!(ti.testsetups, setup1)
     push!(ti.testsetups, setup2)
     push!(ti.testsets, Test.DefaultTestSet("dummy"))

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -406,6 +406,20 @@ end
     end
 end
 
+# Actual `@testitem failfast` behaviour tested in test/integrationtests.jl
+@testset "tesitem `failfast` keyword" begin
+    ti = @testitem "foo" failfast=true _run=false begin
+        @test false
+        @test true
+    end
+    @test ti.failfast == true
+    @test_throws "`failfast` keyword must be passed a `Bool`" (
+        @eval @testitem "bad 1" failfast=nothing begin
+            @test true
+        end
+    )
+end
+
 #=
 NOTE:
     These tests are disabled as we stopped using anonymous modules;

--- a/test/testfiles/_error_test.jl
+++ b/test/testfiles/_error_test.jl
@@ -1,0 +1,7 @@
+@testitem "Test that throws outside of a @test" begin
+    # to make testing easier, we sleep a little to guarantee the format in which the timing
+    # info will print (else it could potentially print "<0.1 secs")
+    sleep(0.5)
+    error("throws")
+    @test true
+end

--- a/test/testfiles/_failfast_crash_tests.jl
+++ b/test/testfiles/_failfast_crash_tests.jl
@@ -1,0 +1,9 @@
+@testitem "good" begin
+    @test true
+end
+@testitem "bad" begin
+    ccall(:abort, Cvoid, ()) # purposefully crash the worker here
+end
+@testitem "may not run" begin
+    @test true
+end

--- a/test/testfiles/_failfast_error_tests.jl
+++ b/test/testfiles/_failfast_error_tests.jl
@@ -1,0 +1,9 @@
+@testitem "good" begin
+    @test true
+end
+@testitem "bad" begin
+    error("failfast error test")
+end
+@testitem "may not run" begin
+    @test true
+end

--- a/test/testfiles/_failfast_failure_tests.jl
+++ b/test/testfiles/_failfast_failure_tests.jl
@@ -1,0 +1,9 @@
+@testitem "good" begin
+    @test true
+end
+@testitem "bad" begin
+    @test false
+end
+@testitem "may not run" begin
+    @test true
+end

--- a/test/testfiles/_failfast_multiple_failure_tests.jl
+++ b/test/testfiles/_failfast_multiple_failure_tests.jl
@@ -1,0 +1,9 @@
+@testitem "bad 1" begin
+    @test false
+end
+@testitem "bad 2" begin
+    @test false
+end
+@testitem "bad 3" begin
+    @test false
+end

--- a/test/testfiles/_failfast_timeout_tests.jl
+++ b/test/testfiles/_failfast_timeout_tests.jl
@@ -1,0 +1,11 @@
+@testitem "good" begin
+    @test true
+end
+@testitem "bad" begin
+    # expected to be run with `timeout=x` with some `x < 10`
+    sleep(10)
+    @test true
+end
+@testitem "may not run" begin
+    @test true
+end

--- a/test/testfiles/_testitem_failfast_set_tests.jl
+++ b/test/testfiles/_testitem_failfast_set_tests.jl
@@ -1,0 +1,19 @@
+@testitem "Failure at toplevel" failfast=true begin
+    sleep(0.1)
+    @test false
+    @test error("ERROR AFTER FAILURE")
+    @testset "Bar" begin
+        @test false
+        @test true
+    end
+end
+
+@testitem "Failure in nested testset" failfast=true begin
+    sleep(0.1)
+    @test true
+    @testset "Bar" begin
+        @test false
+        @test error("ERROR AFTER FAILURE")
+        @test true
+    end
+end

--- a/test/testfiles/_testitem_failfast_tests.jl
+++ b/test/testfiles/_testitem_failfast_tests.jl
@@ -1,0 +1,19 @@
+@testitem "Failure at toplevel" begin
+    sleep(0.1)
+    @test false
+    @test error("ERROR AFTER FAILURE")
+    @testset "Bar" begin
+        @test false
+        @test true
+    end
+end
+
+@testitem "Failure in nested testset" begin
+    sleep(0.1)
+    @test true
+    @testset "Bar" begin
+        @test false
+        @test error("ERROR AFTER FAILURE")
+        @test true
+    end
+end

--- a/test/testfiles/_testset_failfast_tests.jl
+++ b/test/testfiles/_testset_failfast_tests.jl
@@ -1,0 +1,11 @@
+# Testitem containing `@testset failfast=true`
+@testitem "Test.jl failfast=true" begin
+    @testset failfast=true begin
+        @test false
+        @test error("ERROR AFTER FAILURE")
+        @testset "Bar" begin
+            @test false
+            @test true
+        end
+    end
+end

--- a/test/testfiles/_testset_failfast_tests.jl
+++ b/test/testfiles/_testset_failfast_tests.jl
@@ -1,5 +1,5 @@
 # Testitem containing `@testset failfast=true`
-@testitem "Test.jl failfast=true" begin
+@testitem "Test.jl failfast=true keyword" begin
     @testset failfast=true begin
         @test false
         @test error("ERROR AFTER FAILURE")


### PR DESCRIPTION
- Close #132 
- Other test frameworks have a similar option
  - Go `go test` has `-failfast`
  - Rust `cargo test` has `-no-fail-fast`
  - Python `pytest` has `--exitfirst`
  - Ruby `rspec` has `--fail-fast`
  - Javascript `jest` has `bail` (https://jestjs.io/docs/configuration#bail-number--boolean)
 - Also (TIL) the Test.jl stdlib has `failfast` since Julia v1.9 (https://github.com/JuliaLang/julia/commit/88def1afe16acdfe41b15dc956742359d837ce04)
 
Since for us "running tests" involves running test-items which themselves can run multiple tests, we can "fail fast" at two  levels:
- Stop `runtests` from running new testitems as soon as one returns as a failure/error (mark that whole run as a failure)
- Stop `@testitem` from running the tests inside as soon as there is a failure/error (mark that test-item as a failure)
 
Originally this PR added just a `failfast` keyword to `runtests`: `runtests(..., failfast=true)` stops as soon as any testitem fails.

But i've  extended it to add the ability for an `@testitem` to set `failfast=true`: `@testitem "foo" failfast=true` stops on the first test error/failure. This can be set for all test-items by a second new `runtests` keyword named `testitem_failfast`, (i.e. this can be used to set the default for all testitems).

This matches how `@testitem "foo" timeout=60` corresponds to `runtests(...; testitem_timeout=60)`

`failfast` defaults to `false`. I've set `testitem_failfast` to default to the same value as given to `failfast` (if not set explicitly on a `@testitem`). 

So the **proposed behaviour** is:
-  `runtests(...)` =>  **neither** runtests nor individual testitems stop early 
- `runtests(...; failfast=true)` => **both** stop early
- `runtests(...; testitem_failfast=true)` => **only testitems** stop early
- `runtests(...; failfast=true, testitem_failfast=false)` => **only runtests** stops early

### API question

Would it be simpler to have the separate keywords operate independently? 

The downside would be you have to set _both_ to `true` to get "fail fastest", i.e. to both have individual testitems stop when they hit an error/failure, and to have no new testitems run once one has hit an error/failure you have to run with `runtests(...; failfast=true, testitem_failfast=true)`

**Alternative** (keywords operate independently):
-  `runtests(...;)` =>  **neither** runtests nor individual testitems stop early
- `runtests(...; failfast=true)` => **only runtests** stops early
- `runtests(...; testitem_failfast=true)` => **only testitems** stop early
- `runtests(...; failfast=true, testitem_failfast=true)` => **both** stop early

Really the question is **whether `failfast=true` should default to turning on _both_ forms of early stopping (as currently proposed by this PR), or if it should mean only runtests fails fast?**

I would quite like the seperation of the two... one keyword controls one, the other controls the other... BUT I think in practice it is more ergonomic for users to just pass `failfast=true` to get the "fastest" failures (hence proposing that) ...i'd love some feedback on this decision!