### PR TITLE
Very WIP JET integration idea

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "1.23.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 LoggingExtras = "e6f89c97-d47a-5376-807f-9c37f3926c36"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"

--- a/test/internals.jl
+++ b/test/internals.jl
@@ -169,7 +169,7 @@ end # `include_testfiles!` testset
 @testset "report_empty_testsets" begin
     using ReTestItems: TestItem, report_empty_testsets, PerfStats, ScheduledForEvaluation
     using Test: DefaultTestSet, Fail, Error
-    ti = TestItem(Ref(42), "Dummy TestItem", "DummyID", [], false, [], 0, nothing, false, "source/path", 42, ".", nothing)
+    ti = TestItem(Ref(42), "Dummy TestItem", "DummyID", [], false, [], 0, nothing, false, "source/path", 42, ".", nothing, :none)
 
     ts = DefaultTestSet("Empty testset")
     report_empty_testsets(ti, ts)

--- a/test/log_capture.jl
+++ b/test/log_capture.jl
@@ -33,7 +33,7 @@ end
 @testset "log capture -- reporting" begin
     setup1 = @testsetup module TheTestSetup1 end
     setup2 = @testsetup module TheTestSetup2 end
-    ti = TestItem(Ref(42), "TheTestItem", "ID007", [], false, [], 0, nothing, false, "source/path", 42, ".", nothing)
+    ti = TestItem(Ref(42), "TheTestItem", "ID007", [], false, [], 0, nothing, false, "source/path", 42, ".", nothing, :none)
     push!(ti.testsetups, setup1)
     push!(ti.testsetups, setup2)
     push!(ti.testsets, Test.DefaultTestSet("dummy"))


### PR DESCRIPTION
Very WIP and ugly, but consider the following tests with a very contrived bug in the `foo` function:

```julia
# file: jet_tests.jl
@testsetup module Constants
    const DEF = 1
    export DEF
end

@testitem "Test with JET on" jet=:typo setup=[Constants] begin
    using .Threads: @spawn

    @test DEF+1 == 2


    function foo()
        r = Ref(2)
        @spawn ($(r)[] += UNDEF)
        sleep(0.5)
        return r[]
    end
    @test foo() == 2
end

@testitem "Test with JET off" setup=[Constants] begin
    using .Threads: @spawn

    @test DEF+1 == 2


    function foo()
        r = Ref(2)
        @spawn ($(r)[] += UNDEF)
        sleep(0.5)
        return r[]
    end
    @test foo() == 2
end
```
Without JET integration, the test item would happily report 2 passes. With JET integration we do get a failed test about the typo in `foo`:
```
12:57:54 | START (1/2) test item "Test with JET on" at jet_tests.jl:6
12:57:54 | DONE  (1/2) test item "Test with JET on" 0.6 secs (3.5% compile), 1.12 M allocs (65.187 MB)

Error in testset "JET :typo mode" on worker 12811:
...

12:57:55 | START (2/2) test item "Test with JET off" at jet_tests.jl:21
12:57:55 | DONE  (2/2) test item "Test with JET off" 0.5 secs (1.6% compile), 16.59 K allocs (1.197 MB)
Test Summary:           | Pass  Fail  Total  Time
ReTestItems             |    4     1      5  1.6s
  .                     |    4     1      5      
    jet_tests.jl        |    4     1      5      
      Test with JET on  |    2     1      3  0.6s
        JET :typo mode  |          1      1  0.1s
      Test with JET off |    2            2  0.5s
```


When I tried using JET directly the analysis failed to discover the issue and _evaluated_ the code... I'm not sure how to invoke JET to avoid that issue. 
```julia
JET.report_file("jet_tests.jl", context=ReTestItems, concretization_patterns = [:(x_)], mode=:typo) # evaluates the code and fails to find issues
```


