### PR TITLE
WIP log testsetup start/done and timings

### DIFF
--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -856,9 +856,12 @@ function runtestsetup(ts::TestSetup, ctx::TestContext; logs::Symbol)
         mod_expr = :(module $(gensym(ts.name)) end)
         # replace the module expr body with our @testsetup code
         mod_expr.args[3] = ts.code
-        newmod = _redirect_logs(logs == :eager ? DEFAULT_STDOUT[] : ts.logstore[]) do
+        log_testsetup_start(ts)
+        newmod, stats = @timed_with_compilation _redirect_logs(logs == :eager ? DEFAULT_STDOUT[] : ts.logstore[]) do
             with_source_path(() -> Core.eval(Main, mod_expr), ts.file)
         end
+        ts.stats[] = stats
+        log_testsetup_done(ts)
         # add the new module to our TestSetupModules
         mods.modules[ts.name] = newmod
         return nameof(newmod)

--- a/src/log_capture.jl
+++ b/src/log_capture.jl
@@ -55,6 +55,11 @@ function _print_scaled_one_dec(io, value, scale, label="")
     end
     print(io, label)
 end
+function print_time(io::IO, s::PerfStats)
+    return print_time(
+        io; s.elapsedtime, s.bytes, s.gctime, s.allocs, s.compile_time, s.recompile_time
+    )
+end
 function print_time(io; elapsedtime, bytes=0, gctime=0, allocs=0, compile_time=0, recompile_time=0)
     _print_scaled_one_dec(io, elapsedtime, 1e9, " secs")
     if  gctime > 0 || compile_time > 0
@@ -241,7 +246,7 @@ function _print_test_errors(report_iob, ts::DefaultTestSet, worker_info)
     return nothing
 end
 
-function print_state(io, state, ti, ntestitems; color=:default)
+function print_state(io::IO, state::String, ti::TestItem, ntestitems; color=:default)
     interactive = parse(Bool, get(ENV, "RETESTITEMS_INTERACTIVE", string(Base.isinteractive())))
     print(io, format(now(), "HH:MM:SS | "))
     !interactive && print(io, _mem_watermark())
@@ -253,6 +258,13 @@ function print_state(io, state, ti, ntestitems; color=:default)
         printstyled(io, uppercase(state); bold=true)
     end
     print(io, " test item $(repr(ti.name)) ")
+end
+function print_state(io::IO, state::String, ts::TestSetup)
+    interactive = parse(Bool, get(ENV, "RETESTITEMS_INTERACTIVE", string(Base.isinteractive())))
+    print(io, format(now(), "HH:MM:SS | "))
+    !interactive && print(io, _mem_watermark())
+    printstyled(io, rpad(uppercase(state), 5))
+    print(io, " test setup $(ts.name) ")
 end
 
 function print_file_info(io, ti)
@@ -268,7 +280,6 @@ function log_testitem_skipped(ti::TestItem, ntestitems=0)
     write(DEFAULT_STDOUT[], take!(io.io))
 end
 
-# Marks the start of each test item
 function log_testitem_start(ti::TestItem, ntestitems=0)
     io = IOContext(IOBuffer(), :color => get(DEFAULT_STDOUT[], :color, false)::Bool)
     print_state(io, "START", ti, ntestitems)
@@ -276,12 +287,26 @@ function log_testitem_start(ti::TestItem, ntestitems=0)
     println(io)
     write(DEFAULT_STDOUT[], take!(io.io))
 end
+function log_testsetup_start(ts::TestSetup)
+    io = IOContext(IOBuffer(), :color => get(DEFAULT_STDOUT[], :color, false)::Bool)
+    print_state(io, "START", ts)
+    print_file_info(io, ts)
+    println(io)
+    write(DEFAULT_STDOUT[], take!(io.io))
+end
 
 function log_testitem_done(ti::TestItem, ntestitems=0)
     io = IOContext(IOBuffer(), :color => get(DEFAULT_STDOUT[], :color, false)::Bool)
     print_state(io, "DONE", ti, ntestitems)
-    x = last(ti.stats) # always print stats for most recent run
-    print_time(io; x.elapsedtime, x.bytes, x.gctime, x.allocs, x.compile_time, x.recompile_time)
+    stats = last(ti.stats) # always print stats for most recent run
+    print_time(io, stats)
+    println(io)
+    write(DEFAULT_STDOUT[], take!(io.io))
+end
+function log_testsetup_done(ts::TestSetup, ntestitems=0)
+    io = IOContext(IOBuffer(), :color => get(DEFAULT_STDOUT[], :color, false)::Bool)
+    print_state(io, "DONE", ts)
+    print_time(io, ts.stats[])
     println(io)
     write(DEFAULT_STDOUT[], take!(io.io))
 end


### PR DESCRIPTION
- draft of how we could fix #141 (based on top of #138)
- we'd need to decide when/where/how we report the different timings... individual testsetup times, testitem time (excluding testsetups), total testitem time (including testsetups)
<img width="1093" alt="Screenshot 2024-01-20 at 23 21 35" src="https://github.com/JuliaTesting/ReTestItems.jl/assets/13448787/4d0836db-19cd-4ed9-a5d4-13650cadaddf">
