### PR TITLE
Add error element when error/failures happens, even if there are no logs available.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReTestItems"
 uuid = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
-version = "1.23.0"
+version = "1.23.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/junit_xml.jl
+++ b/src/junit_xml.jl
@@ -262,10 +262,12 @@ function write_junit_xml(io, tc::JUnitTestCase)
     write_counts(io, tc.counts)
     write(io, ">")
     write_dd_tags(io, tc)
-    if !isnothing(tc.logs)
-        write(io, "\n\t\t<error")
-        !isnothing(tc.error_message) && write(io, " message=", xml_markup(tc.error_message))
-        write(io, ">", xml_content(strip(String(tc.logs))))
+    if (tc.counts.failures + tc.counts.errors) > 0
+        err_msg = something(tc.error_message, "Test errored but no error message was captured.")
+        write(io, "\n\t\t<error message=", xml_markup(err_msg), ">")
+        if !isnothing(tc.logs)
+            write(io, xml_content(strip(String(tc.logs))))
+        end
         write(io, "\n\t\t</error>")
     end
     write(io, "\n\t</testcase>")


### PR DESCRIPTION
Add error element when error/failures happens, even if there are no logs available. This is needed for Datadog CI test reports, as they require error and/or failure element to indicate failure.