### PR TITLE
Don't error if trying to `rm` already deleted log file

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReTestItems"
 uuid = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
-version = "1.23.2"
+version = "1.23.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -393,7 +393,9 @@ function _runtests_in_current_env(
     finally
         Test.TESTSET_PRINT_ENABLE[] = true
         # Cleanup test setup logs
-        foreach(rm, filter(endswith(".log"), readdir(RETESTITEMS_TEMP_FOLDER[], join=true)))
+        foreach(filter(endswith(".log"), readdir(RETESTITEMS_TEMP_FOLDER[], join=true))) do logfile
+            rm(logfile; force=true)  # `force` to ignore error if file already cleaned up
+        end
     end
     return nothing
 end

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -393,7 +393,7 @@ function _runtests_in_current_env(
     finally
         Test.TESTSET_PRINT_ENABLE[] = true
         # Cleanup test setup logs
-        foreach(filter(endswith(".log"), readdir(RETESTITEMS_TEMP_FOLDER[], join=true))) do logfile
+        foreach(Iterators.filter(endswith(".log"), readdir(RETESTITEMS_TEMP_FOLDER[], join=true))) do logfile
             rm(logfile; force=true)  # `force` to ignore error if file already cleaned up
         end
     end


### PR DESCRIPTION
@charnik reported seeing:
```
12:25:58 | DONE  (1/1) test item "Mutual Recursion" 0.5 secs (7.6% compile, 12.8% GC), 1.81 M allocs (218.272 MB)
Test Summary:                          | Pass  Total  Time
RAICode                                |    3      3  1.8s
  test                                 |    3      3
    test/Views                         |    3      3
      test/Views/view_caching_tests.jl |    3      3
        Mutual Recursion               |    3      3  0.5s
ERROR: IOError: unlink("/tmp/ReTestItemsTempLogsDirectory/ReTestItems_setup_TestTracers_9252552881587737177.log"): no such file or directory (ENOENT)
Stacktrace:
  [1] unlink(p::String)
    @ Base.Filesystem /nix/store/asv3zyg8fzn4zkgkvrjyp8f72c9h86g4-julia-1.10.2/lib/julia/sys.dylib:-1
  [2] rm(path::String; force::Bool, recursive::Bool)
    @ Base.Filesystem /nix/store/asv3zyg8fzn4zkgkvrjyp8f72c9h86g4-julia-1.10.2/lib/julia/sys.dylib:-1
  [3] rm
    @ ./file.jl:273 [inlined]
  [4] foreach
    @ ./abstractarray.jl:3097 [inlined]
  [5] _runtests_in_current_env(shouldrun::Function, paths::Tuple{…}, projectfile::String, nworkers::Int64, nworker_threads::String, worker_init_expr::Expr, test_end_expr::Expr, testitem_timeout::Int64, retries::Int64, memory_threshold::Float64, verbose_results::Bool, debug::Int64, report::Bool, logs::Symbol)
    @ ReTestItems ~/.julia/packages/ReTestItems/ELM7z/src/ReTestItems.jl:394
  [6] (::ReTestItems.var"#47#48"{ReTestItems.var"#shouldrun_combined#45"{String, Nothing, typeof(ReTestItems.default_shouldrun)}, Tuple{String}, Int64, String, Expr, Expr, Int64, Int64, Float64, Bool, Int64, Bool, Symbol, String})()
    @ ReTestItems ~/.julia/packages/ReTestItems/ELM7z/src/ReTestItems.jl:307
  [7] with_logstate(f::Function, logstate::Any)
    @ Base.CoreLogging /nix/store/asv3zyg8fzn4zkgkvrjyp8f72c9h86g4-julia-1.10.2/lib/julia/sys.dylib:-1
  [8] with_logger
    @ ./logging.jl:627 [inlined]
  [9] _runtests(shouldrun::Function, paths::Tuple{String}, nworkers::Int64, nworker_threads::String, worker_init_expr::Expr, test_end_expr::Expr, testitem_timeout::Int64, retries::Int64, memory_threshold::Float64, verbose_results::Bool, debug::Int64, report::Bool, logs::Symbol)
    @ ReTestItems ~/.julia/packages/ReTestItems/ELM7z/src/ReTestItems.jl:290
 [10]
    @ ReTestItems ~/.julia/packages/ReTestItems/ELM7z/src/ReTestItems.jl:260
 [11] runtests
    @ ~/.julia/packages/ReTestItems/ELM7z/src/ReTestItems.jl:212 [inlined]
 [12] top-level scope
    @ ./REPL[3]:1
 [13] eval_user_input(ast::Any, backend::REPL.REPLBackend, mod::Module)
    @ REPL /nix/store/asv3zyg8fzn4zkgkvrjyp8f72c9h86g4-julia-1.10.2/lib/julia/sys.dylib:-1
 [14] repl_backend_loop(backend::REPL.REPLBackend, get_module::Function)
    @ REPL /nix/store/asv3zyg8fzn4zkgkvrjyp8f72c9h86g4-julia-1.10.2/lib/julia/sys.dylib:-1
 [15] start_repl_backend(backend::REPL.REPLBackend, consumer::Any; get_module::Function)
    @ REPL /nix/store/asv3zyg8fzn4zkgkvrjyp8f72c9h86g4-julia-1.10.2/lib/julia/sys.dylib:-1
 [16] run_repl(repl::REPL.AbstractREPL, consumer::Any; backend_on_current_task::Bool, backend::Any)
    @ REPL /nix/store/asv3zyg8fzn4zkgkvrjyp8f72c9h86g4-julia-1.10.2/lib/julia/sys.dylib:-1
 [17] (::Base.var"#1014#1016"{Bool, Bool, Bool})(REPL::Module)
    @ Base /nix/store/asv3zyg8fzn4zkgkvrjyp8f72c9h86g4-julia-1.10.2/lib/julia/sys.dylib:-1
 [18] run_main_repl(interactive::Bool, quiet::Bool, banner::Bool, history_file::Bool, color_set::Bool)
    @ Base /nix/store/asv3zyg8fzn4zkgkvrjyp8f72c9h86g4-julia-1.10.2/lib/julia/sys.dylib:-1
 [19] exec_options(opts::Base.JLOptions)
    @ Base /nix/store/asv3zyg8fzn4zkgkvrjyp8f72c9h86g4-julia-1.10.2/lib/julia/sys.dylib:-1
 [20] _start()
    @ Base /nix/store/asv3zyg8fzn4zkgkvrjyp8f72c9h86g4-julia-1.10.2/lib/julia/sys.dylib:-1




```