### PR TITLE
Get thread and task backtraces before terminating a worker on timeout

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,9 +27,6 @@ jobs:
           - x64
     steps:
       - uses: actions/checkout@v3.5.0
-      - name: Install GDB
-        if: startsWith(matrix.os, 'ubuntu')
-        run: sudo apt-get install -y gdb
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,6 +27,9 @@ jobs:
           - x64
     steps:
       - uses: actions/checkout@v3.5.0
+      - name: Install GDB
+        if: startsWith(matrix.os, 'ubuntu')
+        run: sudo apt-get install -y gdb
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -572,14 +572,14 @@ function manage_worker(
             if e isa TimeoutException
                 @warn "$worker timed out running test item $(repr(testitem.name)) after $timeout seconds."
                 if timeout_profile_wait > 0
-                    @warn "Gathering a CPU profile from the worker."
+                    @info "Gathering a CPU profile from $worker."
                     trigger_profile(worker, timeout_profile_wait, :timeout)
                 end
                 if timeout_backtraces
-                    @warn "Gathering thread and task backtraces from the worker."
+                    @info "Gathering thread and task backtraces from $worker."
                     trigger_backtraces(worker, :timeout)
                 end
-                @warn "Terminating the worker."
+                @info "Terminating $worker."
                 terminate!(worker, :timeout)
                 wait(worker)
                 # TODO: We print the captured logs after the worker is terminated,

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -571,13 +571,14 @@ function manage_worker(
             # Handle the exception
             if e isa TimeoutException
                 @warn "$worker timed out running test item $(repr(testitem.name)) after $timeout seconds."
+                xtra_output = nothing
                 if timeout_profile_wait > 0
                     @info "Gathering a CPU profile from $worker."
                     trigger_profile(worker, timeout_profile_wait, :timeout)
                 end
                 if timeout_backtraces
                     @info "Gathering thread and task backtraces from $worker."
-                    trigger_backtraces(worker, :timeout)
+                    xtra_output = trigger_backtraces(worker, :timeout)
                 end
                 @info "Terminating $worker."
                 terminate!(worker, :timeout)
@@ -588,6 +589,7 @@ function manage_worker(
                 # This is not an issue with eager logs, but when going through a file, this seems to help.
                 println(DEFAULT_STDOUT[])
                 _print_captured_logs(DEFAULT_STDOUT[], testitem, run_number)
+                isnothing(xtra_output) || println(DEFAULT_STDOUT[], xtra_output)
                 @error "$worker timed out running test item $(repr(testitem.name)) after $timeout seconds. \
                     Recording test error."
                 record_timeout!(testitem, run_number, timeout)

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -428,7 +428,7 @@ function start_worker(proj_name, nworker_threads, worker_init_expr, ntestitems; 
         const GLOBAL_TEST_CONTEXT = ReTestItems.TestContext($proj_name, $ntestitems)
         GLOBAL_TEST_CONTEXT.setups_evaled = ReTestItems.TestSetupModules()
         nthreads_str = $nworker_threads
-        @info "Starting test worker$($i) on pid = $(Libc.getpid()), with $nthreads_str threads"
+        @info "Starting test worker$($i) on pid = $(Libc.getpid()), with $nthreads_str threads, nthreads(:default) = $(Base.Threads.nthreads(:default)), nthreads(:interactive) = $(Base.Threads.nthreads(:interactive))"
         $(worker_init_expr.args...)
         nothing
     end)

--- a/src/workers.jl
+++ b/src/workers.jl
@@ -126,11 +126,12 @@ function trigger_profile(w::Worker, timeout_profile_wait, from::Symbol=:manual)
 end
 
 # Spawn GDB to request thread backtraces followed by invoking jl_print_task_backtraces
-# to get task backtraces. We wait for GDB to finish so no sleep is needed.
+# to get task backtraces. We wait for GDB to finish so no sleep is needed. Thread backtraces
+# are written to `gdb.btall`, which is overwritten if present.
 function trigger_backtraces(w::Worker, from::Symbol=:manual)
     if Sys.islinux()
         @debug "using GDB to get thread and task backtraces on worker $(w.pid) from $from"
-        gdb_cmd = `gdb -ex "handle SIGSEGV noprint nostop pass" -ex "set pagination 0" -ex "thread apply all bt" -ex "call jl_print_task_backtraces(1)" --batch -p $(w.pid)`
+        gdb_cmd = `gdb -ex "handle SIGSEGV noprint nostop pass" -ex "handle SIGUSR2 noprint nostop pass" -ex "set pagination 0" -ex "set logging overwrite on" -ex "set logging file gdb.btall" -ex "set logging redirect on" -ex "set logging enabled on" -ex "thread apply all bt" -ex "set logging enabled off" -ex "call jl_print_task_backtraces(1)" --batch -p $(w.pid)`
         try
             run(gdb_cmd; wait = true) # if `wait = false`, std* are redirected to devnull
         catch e

--- a/src/workers.jl
+++ b/src/workers.jl
@@ -134,7 +134,7 @@ end
 function trigger_backtraces(w::Worker, from::Symbol=:manual)
     if Sys.islinux()
         @debug "using GDB to get thread and task backtraces on worker $(w.pid) from $from"
-        iob = IOBuffer()
+        #iob = IOBuffer()
         gdb_cmd = Cmd([
             "gdb",
             # Run in batched mode on the worker process
@@ -154,10 +154,11 @@ function trigger_backtraces(w::Worker, from::Symbol=:manual)
             )
         end
 =#
-        push!(gdb_cmd.exec, "-ex", "detach")
         try
-            run(pipeline(gdb_cmd, stdout=iob, stderr=iob))
-            return String(take!(iob))
+            println("Running $(gdb_cmd)")
+            run(gdb_cmd)
+            #run(pipeline(gdb_cmd, stdout=iob, stderr=iob))
+            #return String(take!(iob))
         catch e
             @warn "Could not get thread/task backtraces via GDB." exception=e
         end

--- a/src/workers.jl
+++ b/src/workers.jl
@@ -135,7 +135,7 @@ function trigger_backtraces(w::Worker, from::Symbol=:manual)
         try
             run(gdb_cmd; wait = true) # if `wait = false`, std* are redirected to devnull
         catch e
-            @warn "Could not get thread/task backtraces via GDB.\n$(sprint(showerror, e))"
+            @warn "Could not get thread/task backtraces via GDB." exception=e
         end
     end
     return nothing

--- a/src/workers.jl
+++ b/src/workers.jl
@@ -145,11 +145,17 @@ function trigger_backtraces(w::Worker, from::Symbol=:manual)
             "-ex", "set pagination 0",
             # Get all thread backtraces
             "-ex", "thread apply all bt",
-            # Ask Julia to dump all task backtraces
-            "-ex", "call jl_print_task_backtraces(1)",
-            # Run all commands above in batched mode
-            "--batch", "-p", "$(w.pid)"
         ])
+        @static if VERSION >= v"1.9"
+            push!(gdb_cmd.exec,
+                # Ask Julia to dump all task backtraces
+                "-ex", "call jl_print_task_backtraces(1)",
+            )
+        end
+        push!(gdb_cmd.exec,
+            # Run all commands above in batched mode
+            "--batch", "-p", "$(w.pid)",
+        )
         try
             run(pipeline(gdb_cmd, stdout=iob, stderr=iob))
             return String(take!(iob))

--- a/src/workers.jl
+++ b/src/workers.jl
@@ -146,12 +146,14 @@ function trigger_backtraces(w::Worker, from::Symbol=:manual)
             # Get all thread backtraces
             "-ex", "thread apply all bt",
         ])
+#=
         @static if VERSION >= v"1.9"
             push!(gdb_cmd.exec,
                 # Ask Julia to dump all task backtraces
                 "-ex", "call jl_print_task_backtraces(1)",
             )
         end
+=#
         push!(gdb_cmd.exec,
             # Run all commands above in batched mode
             "--batch", "-p", "$(w.pid)",

--- a/test/integrationtests.jl
+++ b/test/integrationtests.jl
@@ -929,10 +929,14 @@ end
         if gdb_available()
             if Sys.islinux()
                 @test occursin("in signal_listener", logs)
+            else
+                @test_skip "not on Linux"
             end
             @test count(r"pthread_cond_wait|__psych_cvwait", logs) > 0 # the stacktrace was printed (will fail on Windows)
-            @test occursin("==== Thread 1 created", logs)
-            @test occursin("==== End thread 1", logs)
+            if VERSION >= v"1.9" # jl_print_task_backtraces() output
+                @test occursin("==== Thread 1 created", logs)
+                @test occursin("==== End thread 1", logs)
+            end
         else
             @test_skip "gdb unavailable"
         end
@@ -944,7 +948,7 @@ end
     withenv("RETESTITEMS_TIMEOUT_BACKTRACES" => "true") do
         capture_timeout_backtraces(nothing) do logs
             if gdb_available()
-                @test occursin("==== Thread 1 created", logs)
+                @test occursin("Thread 1", logs)
             else
                 @test_skip "gdb unavailable"
             end

--- a/test/integrationtests.jl
+++ b/test/integrationtests.jl
@@ -936,6 +936,8 @@ end
             @test count(r"pthread_cond_wait|__psych_cvwait", logs) > 0 # the stacktrace was printed (will fail on Windows)
             @test occursin("==== Thread 1 created", logs)
             @test occursin("==== End thread 1", logs)
+        else
+            @test_skip "gdb unavailable"
         end
         end
     end
@@ -946,6 +948,8 @@ end
         capture_timeout_backtraces(nothing) do logs
             if gdb_available()
                 @test occursin("==== Thread 1 created", logs)
+            else
+                @test_skip "gdb unavailable"
             end
             end
         end


### PR DESCRIPTION
Implements the alternative described in https://github.com/JuliaTesting/ReTestItems.jl/issues/105 as an option.

> Alternatively, we could dump julia task backtraces and/or CPU stacktraces.

I think a similar incantation can be assembled for `lldb`, to support Mac. We could support FreeBSD/OpenBSD since they have `gdb`, but I don't have a machine that would let me test. Note that `Sys.isbsd()` returns `true` for Mac.