### PR TITLE
[RAI-28133] Output an error when `worker_init_expr` is set but test workers are zero

### DIFF
--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -343,6 +343,9 @@ function _runtests_in_current_env(
         (nworkers == 0 ? "" : " with $nworkers worker processes and $nworker_threads threads per worker.")
     try
         if nworkers == 0
+            if length(worker_init_expr.args) > 0
+                error("worker_init_expr is set, but will not run because number of workers is 0.")
+            end
             # This is where we disable printing for the serial executor case.
             Test.TESTSET_PRINT_ENABLE[] = false
             ctx = TestContext(proj_name, ntestitems)

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -343,9 +343,7 @@ function _runtests_in_current_env(
         (nworkers == 0 ? "" : " with $nworkers worker processes and $nworker_threads threads per worker.")
     try
         if nworkers == 0
-            if length(worker_init_expr.args) > 0
-                error("worker_init_expr is set, but will not run because number of workers is 0.")
-            end
+            length(worker_init_expr.args) > 0 && error("worker_init_expr is set, but will not run because number of workers is 0.")
             # This is where we disable printing for the serial executor case.
             Test.TESTSET_PRINT_ENABLE[] = false
             ctx = TestContext(proj_name, ntestitems)

--- a/test/integrationtests.jl
+++ b/test/integrationtests.jl
@@ -224,6 +224,17 @@ end
     end
 end
 
+@testset "runtests a dir with 0 nworkers but worker_init_expr set" verbose=true begin
+    # Doesn't actually matter what it's set to, just that it's set.
+    worker_init_expr =:(1+1)
+    results = encased_testset() do
+        runtests(joinpath(TEST_PKG_DIR, "NoDeps.jl"); worker_init_expr)
+    end
+
+    @test n_passed(results) == 0
+    @test length(errors(results)) == 1
+end
+
 nworkers = 2
 @testset "runtests with nworkers = $nworkers" verbose=true begin
     @testset "Pkg.test() $pkg" for pkg in TEST_PKGS


### PR DESCRIPTION
Currently, if test workers are zero, `worker_init_expr` won't run even if it's defined.
This PR returns an error in this case.

A `@testset` is added in `test/integrationtests.jl`.