### PR TITLE
Always run the test_end_expr, even if the test throws an exception.

### DIFF
--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -935,10 +935,16 @@ end
 # when `runtestitem` called directly or `@testitem` called outside of `runtests`.
 function runtestitem(
     ti::TestItem, ctx::TestContext;
-    test_end_expr::Expr=Expr(:block), logs::Symbol=:eager, verbose_results::Bool=true, finish_test::Bool=true,
+    test_end_expr::Union{Nothing,Expr}=nothing, logs::Symbol=:eager, verbose_results::Bool=true, finish_test::Bool=true,
 )
     if should_skip(ti)::Bool
         return skiptestitem(ti, ctx; verbose_results)
+    end
+    if test_end_expr === nothing
+        has_test_end_expr = false
+        test_end_expr = Expr(:block)
+    else
+        has_test_end_expr = true
     end
     name = ti.name
     log_testitem_start(ti, ctx.ntestitems)
@@ -1004,8 +1010,13 @@ function runtestitem(
         # environment = Module()
         @debugv 1 "Running test item $(repr(name))$(_on_worker())."
         _, stats = @timed_with_compilation _redirect_logs(logs == :eager ? DEFAULT_STDOUT[] : logpath(ti)) do
-            with_source_path(() -> Core.eval(Main, mod_expr), ti.file)
-            with_source_path(() -> Core.eval(Main, test_end_mod_expr), ti.file)
+            # Always run the test_end_mod_expr, even if the test item fails / throws
+            try
+                with_source_path(() -> Core.eval(Main, mod_expr), ti.file)
+            finally
+                has_test_end_expr && @debugv 1 "Running test_end_expr for test item $(repr(name))$(_on_worker())."
+                with_source_path(() -> Core.eval(Main, test_end_mod_expr), ti.file)
+            end
             nothing # return nothing as the first return value of @timed_with_compilation
         end
         @debugv 1 "Done running test item $(repr(name))$(_on_worker())."

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -168,6 +168,8 @@ will be run.
   By default, the expression is `GC.gc(true)`, when `nworkers > 1`, to help with memory pressure,
   otherwise it is a no-op.
   Can be used to verify that global state is unchanged after running a test. Must be a `:block` expression.
+  The `test_end_expr` is evaluated whether a testitem passes, fails, or errors. If the
+  `testsetup` fails, then the `test_end_expr` is not run.
 - `memory_threshold::Real`: Sets the fraction of memory that can be in use before a worker processes are
   restarted to free memory. Defaults to $(DEFAULT_MEMORY_THRESHOLD[]). Only supported with `nworkers > 0`.
   For example, if set to 0.8, then when >80% of the available memory is in use, a worker process will be killed and

--- a/test/integrationtests.jl
+++ b/test/integrationtests.jl
@@ -1086,9 +1086,9 @@ mutable struct AtomicCounter{T}; @atomic x::T; end
         @show length(failures(dont_pass_results))
         @show length(errors(dont_pass_results))
         Test.print_test_results(dont_pass_results)
-        number_of_bad_setup_tests = 2
-        # TODO(PR): This should be counting the number of testitems, not the number of tests.
-        @test n_tests(dont_pass_results) - number_of_bad_setup_tests == @atomic(end_expr_count.x)
+        # This is the total number of testitems in DontPass.jl, minus those with
+        # nonexistent testsetups, or errors in the testsetup.
+        @test @atomic(end_expr_count.x) == 7
     end
 end
 

--- a/test/integrationtests.jl
+++ b/test/integrationtests.jl
@@ -1085,7 +1085,10 @@ mutable struct AtomicCounter{T}; @atomic x::T; end
         @show n_passed(dont_pass_results)
         @show length(failures(dont_pass_results))
         @show length(errors(dont_pass_results))
-        @test n_tests(dont_pass_results) == @atomic(end_expr_count.x)
+        Test.print_test_results(dont_pass_results)
+        number_of_bad_setup_tests = 2
+        # TODO(PR): This should be counting the number of testitems, not the number of tests.
+        @test n_tests(dont_pass_results) - number_of_bad_setup_tests == @atomic(end_expr_count.x)
     end
 end
 


### PR DESCRIPTION
Put the test_end_expr running in a try/finally.

Also adds a debugv log for running the test_end_expr.
Adds tests.

--------

I made the following design decision:
- We run the test_end_expr iff we run the testitem.
    - i.e. If the testsetup fails or does not exist, we do not start the testitem and therefore do not run the test_end_expr.

Let me know if that doesn't sound right to you.