### PR TITLE
Improve reporting of parse errors in test files

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReTestItems"
 uuid = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
-version = "1.24.0"
+version = "1.25.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -653,6 +653,11 @@ end
 #   i.e. Only `@testitem` and `@testsetup` calls are officially supported.
 checked_include(mod, filepath) = Base.include(check_retestitem_macrocall, mod, filepath)
 function check_retestitem_macrocall(expr)
+    if Meta.isexpr(expr, :error)
+        # If the expression failed to parse, most user-friendly to throw the ParseError,
+        # rather than report an error about using only `@testitem` or `@testsetup`.
+        Core.eval(Main, expr)
+    end
     is_retestitem_macrocall(expr) || _throw_not_macrocall(expr)
     return expr
 end

--- a/test/integrationtests.jl
+++ b/test/integrationtests.jl
@@ -1141,4 +1141,13 @@ end
     @test contains(c1.output, r"SKIP  \(3/6\) test item \"skip true\"")
 end
 
+@testset "ParseError in test file" begin
+    file = joinpath(TEST_FILES_DIR, "_parse_error_test.jl")
+    # the actual error type will be a TaskFailedException, containing a LoadError,
+    # containing a ParseError, but what we care about is that ultimately the ParseError is
+    # displayed, so we just check for that.
+    @test_throws ["ParseError:", "Expected `]`"] runtests(file; nworkers=0)
+    @test_throws ["ParseError:", "Expected `]`"] runtests(file; nworkers=1)
+end
+
 end # integrationtests.jl testset

--- a/test/integrationtests.jl
+++ b/test/integrationtests.jl
@@ -1147,9 +1147,9 @@ end
     # containing a ParseError, but what we care about is that ultimately the ParseError is
     # displayed, so we just check for that.
     # Only v1.10+ has the newer Parser with better error messages.
-    expected = VERSION < v"1.10" ? "ParseError:" : ["ParseError:", "Expected `]`"]
-    @test_throws ["ParseError:", "Expected `]`"] runtests(file; nworkers=0)
-    @test_throws ["ParseError:", "Expected `]`"] runtests(file; nworkers=1)
+    expected = VERSION < v"1.10" ? "syntax:" : ["ParseError:", "Expected `]`"]
+    @test_throws expected runtests(file; nworkers=0)
+    @test_throws expected runtests(file; nworkers=1)
 end
 
 end # integrationtests.jl testset

--- a/test/integrationtests.jl
+++ b/test/integrationtests.jl
@@ -1146,6 +1146,8 @@ end
     # the actual error type will be a TaskFailedException, containing a LoadError,
     # containing a ParseError, but what we care about is that ultimately the ParseError is
     # displayed, so we just check for that.
+    # Only v1.10+ has the newer Parser with better error messages.
+    expected = VERSION < v"1.10" ? "ParseError:" : ["ParseError:", "Expected `]`"]
     @test_throws ["ParseError:", "Expected `]`"] runtests(file; nworkers=0)
     @test_throws ["ParseError:", "Expected `]`"] runtests(file; nworkers=1)
 end

--- a/test/testfiles/_parse_error_test.jl
+++ b/test/testfiles/_parse_error_test.jl
@@ -1,0 +1,5 @@
+# Test case for https://github.com/JuliaTesting/ReTestItems.jl/issues/166
+@testitem "file_doesnt_parse" begin
+    # Note the missing `]`
+    @test ["a", "b"] == ["a", "b"
+end


### PR DESCRIPTION
close #166 (cc @mbarbar)

Before:
```julia
julia> runtests("test/testfiles/_parse_error_test.jl"; nworkers=1)
[ Info: Scanning for test items in project `ReTestItems` at paths: test/foo_test.jl
ERROR: TaskFailedException

    nested task error: LoadError: Test files must only include `@testitem` and `@testsetup` calls.
    In "/Users/nickr/repos/ReTestItems.jl/test/foo_test.jl" got:
        $(Expr(:error, Base.Meta.ParseError("ParseError:\n# Error @ /Users/nickr/repos/ReTestItems.jl/test/foo_test.jl:5:1\n    @test [\"a\", \"b\"] == [\"a\", \"b\"\nend\n└ ── Expected `]`", Base.JuliaSyntax.ParseError(Base.JuliaSyntax.SourceFile("# Test case for https://github.com/JuliaTesting/ReTestItems.jl/issues/166\n@testitem \"file_doesnt_parse\" begin\n    # Note the missing `]`\n    @test [\"a\", \"b\"] == [\"a\", \"b\"\nend\n", 0, "/Users/nickr/repos/ReTestItems.jl/test/foo_test.jl", 1, [1, 75, 111, 138, 172, 176]), Base.JuliaSyntax.Diagnostic[Base.JuliaSyntax.Diagnostic(172, 171, :error, "Expected `]`")], :none))))

    Stacktrace:
      [1] error(s::String)
        @ Base ./error.jl:35
      [2] _throw_not_macrocall(expr::Expr)
        @ ReTestItems ~/repos/ReTestItems.jl/src/ReTestItems.jl:679
      [3] check_retestitem_macrocall(expr::Expr)
        @ ReTestItems ~/repos/ReTestItems.jl/src/ReTestItems.jl:656
      [4] include_string(mapexpr::typeof(ReTestItems.check_retestitem_macrocall), mod::Module, code::String, filename::String)
        @ Base ./loading.jl:2080
      [5] _include(mapexpr::Function, mod::Module, _path::String)
        @ Base ./loading.jl:2144
      [6] include
        @ ./Base.jl:496 [inlined]
      [7] checked_include
        @ ~/repos/ReTestItems.jl/src/ReTestItems.jl:654 [inlined]
      [8] #70
        @ ~/repos/ReTestItems.jl/src/ReTestItems.jl:743 [inlined]
      [9] task_local_storage(body::ReTestItems.var"#70#76"{String}, key::Symbol, val::Channel{Pair{Symbol, TestSetup}})
        @ Base ./task.jl:297
     [10] #69
        @ ~/repos/ReTestItems.jl/src/ReTestItems.jl:742 [inlined]
     [11] task_local_storage(body::ReTestItems.var"#69#75"{Channel{Pair{Symbol, TestSetup}}, String}, key::Symbol, val::String)
        @ Base ./task.jl:297
     [12] #68
        @ ~/repos/ReTestItems.jl/src/ReTestItems.jl:741 [inlined]
     [13] task_local_storage(body::ReTestItems.var"#68#74"{…}, key::Symbol, val::Tuple{…})
        @ Base ./task.jl:297
     [14] #67
        @ ~/repos/ReTestItems.jl/src/ReTestItems.jl:740 [inlined]
     [15] task_local_storage(body::ReTestItems.var"#67#73"{…}, key::Symbol, val::Bool)
        @ Base ./task.jl:297
     [16] (::ReTestItems.var"#66#72"{ReTestItems.FileNode, Set{String}, String, Channel{Pair{Symbol, TestSetup}}, String})()
        @ ReTestItems ~/repos/ReTestItems.jl/src/ReTestItems.jl:739
    in expression starting at /Users/nickr/repos/ReTestItems.jl/test/foo_test.jl:5
Stacktrace:
  [1] sync_end(c::Channel{Any})
    @ Base ./task.jl:448
  [2] macro expansion
    @ ./task.jl:480 [inlined]
  [3] include_testfiles!(project_name::String, projectfile::String, paths::Tuple{…}, shouldrun::Function, verbose_results::Bool, report::Bool)
    @ ReTestItems ~/repos/ReTestItems.jl/src/ReTestItems.jl:702
  [4] _runtests_in_current_env(shouldrun::Function, paths::Tuple{…}, projectfile::String, nworkers::Int64, nworker_threads::String, worker_init_expr::Expr, test_end_expr::Expr, testitem_timeout::Int64, retries::Int64, memory_threshold::Float64, verbose_results::Bool, debug::Int64, report::Bool, logs::Symbol, timeout_profile_wait::Int64)
    @ ReTestItems ~/repos/ReTestItems.jl/src/ReTestItems.jl:338
  [5] (::ReTestItems.var"#47#48"{…})()
    @ ReTestItems ~/repos/ReTestItems.jl/src/ReTestItems.jl:320
  [6] with_logstate(f::Function, logstate::Any)
    @ Base.CoreLogging ./logging.jl:515
  [7] with_logger
    @ ./logging.jl:627 [inlined]
  [8] _runtests(shouldrun::Function, paths::Tuple{…}, nworkers::Int64, nworker_threads::String, worker_init_expr::Expr, test_end_expr::Expr, testitem_timeout::Int64, retries::Int64, memory_threshold::Float64, verbose_results::Bool, debug::Int64, report::Bool, logs::Symbol, timeout_profile_wait::Int64)
    @ ReTestItems ~/repos/ReTestItems.jl/src/ReTestItems.jl:303
  [9]
    @ ReTestItems ~/repos/ReTestItems.jl/src/ReTestItems.jl:273
 [10] #runtests#40
    @ ~/repos/ReTestItems.jl/src/ReTestItems.jl:221 [inlined]
 [11] top-level scope
    @ REPL[20]:1
Some type information was truncated. Use `show(err)` to see complete types.

```
Now:
```julia
julia> runtests("test/testfiles/_parse_error_test.jl"; nworkers=1)
[ Info: Scanning for test items in project `ReTestItems` at paths: test/testfiles/_parse_error_test.jl
ERROR: TaskFailedException

    nested task error: LoadError: ParseError:
    # Error @ /Users/nickr/repos/ReTestItems.jl/test/testfiles/_parse_error_test.jl:5:1
        @test ["a", "b"] == ["a", "b"
    end
    └ ── Expected `]`
    Stacktrace:
      [1] top-level scope
        @ none:1
      [2] eval
        @ ./boot.jl:385 [inlined]
      [3] check_retestitem_macrocall(expr::Expr)
        @ ReTestItems ~/repos/ReTestItems.jl/src/ReTestItems.jl:659
      [4] include_string(mapexpr::typeof(ReTestItems.check_retestitem_macrocall), mod::Module, code::String, filename::String)
        @ Base ./loading.jl:2080
      [5] _include(mapexpr::Function, mod::Module, _path::String)
        @ Base ./loading.jl:2144
      [6] include
        @ ./Base.jl:496 [inlined]
      [7] checked_include
        @ ~/repos/ReTestItems.jl/src/ReTestItems.jl:654 [inlined]
      [8] #70
        @ ~/repos/ReTestItems.jl/src/ReTestItems.jl:743 [inlined]
      [9] task_local_storage(body::ReTestItems.var"#70#76"{String}, key::Symbol, val::Channel{Pair{Symbol, TestSetup}})
        @ Base ./task.jl:297
     [10] #69
        @ ~/repos/ReTestItems.jl/src/ReTestItems.jl:742 [inlined]
     [11] task_local_storage(body::ReTestItems.var"#69#75"{Channel{Pair{Symbol, TestSetup}}, String}, key::Symbol, val::String)
        @ Base ./task.jl:297
     [12] #68
        @ ~/repos/ReTestItems.jl/src/ReTestItems.jl:741 [inlined]
     [13] task_local_storage(body::ReTestItems.var"#68#74"{…}, key::Symbol, val::Tuple{…})
        @ Base ./task.jl:297
     [14] #67
        @ ~/repos/ReTestItems.jl/src/ReTestItems.jl:740 [inlined]
     [15] task_local_storage(body::ReTestItems.var"#67#73"{…}, key::Symbol, val::Bool)
        @ Base ./task.jl:297
     [16] (::ReTestItems.var"#66#72"{ReTestItems.FileNode, Set{String}, String, Channel{Pair{Symbol, TestSetup}}, String})()
        @ ReTestItems ~/repos/ReTestItems.jl/src/ReTestItems.jl:739
    in expression starting at /Users/nickr/repos/ReTestItems.jl/test/testfiles/_parse_error_test.jl:5
Stacktrace:
  [1] sync_end(c::Channel{Any})
    @ Base ./task.jl:448
  [2] macro expansion
    @ ./task.jl:480 [inlined]
  [3] include_testfiles!(project_name::String, projectfile::String, paths::Tuple{…}, shouldrun::Function, verbose_results::Bool, report::Bool)
    @ ReTestItems ~/repos/ReTestItems.jl/src/ReTestItems.jl:707
  [4] _runtests_in_current_env(shouldrun::Function, paths::Tuple{…}, projectfile::String, nworkers::Int64, nworker_threads::String, worker_init_expr::Expr, test_end_expr::Expr, testitem_timeout::Int64, retries::Int64, memory_threshold::Float64, verbose_results::Bool, debug::Int64, report::Bool, logs::Symbol, timeout_profile_wait::Int64)
    @ ReTestItems ~/repos/ReTestItems.jl/src/ReTestItems.jl:338
  [5] (::ReTestItems.var"#47#48"{…})()
    @ ReTestItems ~/repos/ReTestItems.jl/src/ReTestItems.jl:320
  [6] with_logstate(f::Function, logstate::Any)
    @ Base.CoreLogging ./logging.jl:515
  [7] with_logger
    @ ./logging.jl:627 [inlined]
  [8] _runtests(shouldrun::Function, paths::Tuple{…}, nworkers::Int64, nworker_threads::String, worker_init_expr::Expr, test_end_expr::Expr, testitem_timeout::Int64, retries::Int64, memory_threshold::Float64, verbose_results::Bool, debug::Int64, report::Bool, logs::Symbol, timeout_profile_wait::Int64)
    @ ReTestItems ~/repos/ReTestItems.jl/src/ReTestItems.jl:303
  [9]
    @ ReTestItems ~/repos/ReTestItems.jl/src/ReTestItems.jl:273
 [10] #runtests#40
    @ ~/repos/ReTestItems.jl/src/ReTestItems.jl:221 [inlined]
 [11] top-level scope
    @ REPL[19]:1
Some type information was truncated. Use `show(err)` to see complete types.

```