### PR TITLE
Move GC out of `test_end_expr` to its own keyword `gc_between_testitems`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReTestItems"
 uuid = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
-version = "1.25.0"
+version = "1.25.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -377,9 +377,9 @@ function _runtests_in_current_env(
                 end
             end
         elseif !isempty(testitems.testitems)
-            # Try to free up memory on the coordinator before starting workers
-            #
-            GC.gc(true) # TODO: why do we need to force GC here? do we need a full sweep?
+            # Try to free up memory on the coordinator before starting workers, since
+            # the workers won't be able to collect it if they get under memory pressure.
+            GC.gc(true)
             # Use the logger that was set before we eval'd any user code to avoid world age
             # issues when logging https://github.com/JuliaLang/julia/issues/33865
             original_logger = current_logger()
@@ -559,9 +559,8 @@ function manage_worker(
                 print_errors_and_captured_logs(testitem, run_number; logs)
                 report_empty_testsets(testitem, ts)
                 if gc_between_testitems
-                    # Run GC to free memory on the worker before next testitem.
                     @debugv 2 "Running GC on $worker"
-                    remote_fetch(worker, :(GC.gc(true))) # TODO: do we need a full sweep?
+                    remote_fetch(worker, :(GC.gc(true)))
                 end
                 if any_non_pass(ts) && run_number != max_runs
                     run_number += 1

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -168,7 +168,7 @@ will be run.
   Can be used to verify that global state is unchanged after running a test. Must be a `:block` expression.
 - `gc_between_testitems::Bool`: If `true`, a full garbage collection (GC) will be run after each test item is run.
   Defaults to `nworkers > 1`, i.e. `true` when running with multiple worker processes, since multiple worker processes
-  cannot coordinate to trigger Julia's GC, and should not be necessary to invoke the GC directly if running with without
+  cannot coordinate to trigger Julia's GC, and it should not be necessary to invoke the GC directly if running with without
   workers or with a single worker (since the GC will be triggered automatically by the single process running all the tests).
   Can also be set using the `RETESTITEMS_GC_BETWEEN_TESTITEMS` environment variable.
   Tip: For complete control over GC, set `gc_between_testitems=false` and manually trigger GC in `test_end_expr`.

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -168,7 +168,7 @@ will be run.
   Can be used to verify that global state is unchanged after running a test. Must be a `:block` expression.
 - `gc_between_testitems::Bool`: If `true`, a full garbage collection (GC) will be run after each test item is run.
   Defaults to `nworkers > 1`, i.e. `true` when running with multiple worker processes, since multiple worker processes
-  cannot coordinate to trigger Julia's GC, and it should not be necessary to invoke the GC directly if running with without
+  cannot coordinate to trigger Julia's GC, and it should not be necessary to invoke the GC directly if running without
   workers or with a single worker (since the GC will be triggered automatically by the single process running all the tests).
   Can also be set using the `RETESTITEMS_GC_BETWEEN_TESTITEMS` environment variable.
   Tip: For complete control over GC, set `gc_between_testitems=false` and manually trigger GC in `test_end_expr`.

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -166,12 +166,12 @@ will be run.
   Can be used to load packages or set up the environment. Must be a `:block` expression.
 - `test_end_expr::Expr`: an expression that will be run after each testitem is run.
   Can be used to verify that global state is unchanged after running a test. Must be a `:block` expression.
-- `gc_between_testitems::Bool`: If `true`, a full garbage collection (GC) will be run on the worker process
-  after each test item is run. This can be useful to free up memory between test items, especially when running
-  with multiple worker processes, since those processes cannot coordinate to trigger Julia's GC.
-  Defaults to `nworkers > 1`, i.e. `true` when running with multiple worker processes.
+- `gc_between_testitems::Bool`: If `true`, a full garbage collection (GC) will be run after each test item is run.
+  Defaults to `nworkers > 1`, i.e. `true` when running with multiple worker processes, since multiple worker processes
+  cannot coordinate to trigger Julia's GC, and should not be necessary to invoke the GC directly if running with without
+  workers or with a single worker (since the GC will be triggered automatically by the single process running all the tests).
   Can also be set using the `RETESTITEMS_GC_BETWEEN_TESTITEMS` environment variable.
-  Tip: For complete control over GC, set `gc_between_testitems=false` and manually trigger GC from `test_end_expr`.
+  Tip: For complete control over GC, set `gc_between_testitems=false` and manually trigger GC in `test_end_expr`.
 - `memory_threshold::Real`: Sets the fraction of memory that can be in use before a worker processes are
   restarted to free memory. Defaults to $(DEFAULT_MEMORY_THRESHOLD[]). Only supported with `nworkers > 0`.
   For example, if set to 0.8, then when >80% of the available memory is in use, a worker process will be killed and


### PR DESCRIPTION
See https://github.com/JuliaTesting/ReTestItems.jl/pull/160#issuecomment-2273078012

PR#160 tidied up when we're invoking GC manually, and made it more user-controllable. This PR moves the user-control to be separate from the `test_end_expr`, in order to avoid users being forced to think about GC if they want to use `test_end_expr`. 

Marking this a bug-fix, since the last release contained PR#160 and means that anyone with an existing `test_end_expr` running with multiple workers would have experienced the complete removal of GC between test-items, whereas we only wanted them to benefit from the stream-lined invocation of GC (i.e. reduced to only being invoked if there are multiple workers, and only a single full pass).