### PR TITLE
fix windows failure

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -112,7 +112,7 @@ those test in their own module.
 Should only be created via the `@testitem` macro.
 """
 struct TestItem
-    number::Base.RefValue{Int64} # populated by runtests coordinator once all test items are known
+    number::Base.RefValue{Int} # populated by runtests coordinator once all test items are known
     name::String
     id::String # in case file/name isn't a sufficiently stable identifier for reporting purposes
     tags::Vector{Symbol}


### PR DESCRIPTION
fixes a windows failure due to asserting Int64 when the architecture may be Int32

```
 ERROR: LoadError: TaskFailedException

    nested task error: LoadError: MethodError: Cannot `convert` an object of type 
      Base.RefValue{Int32} to an object of type 
      Base.RefValue{Int64}
    
    Closest candidates are:
      convert(::Type{T}, ::T) where T
       @ Base Base.jl:84
      Base.RefValue{T}(::Any) where T
       @ Base refvalue.jl:8
    
    Stacktrace:
      [1] TestItem(number::Base.RefValue{Int32}, name::String, id::String, tags::Vector{Symbol}, default_imports::Bool, setups::Vector{Any}, retries::Int32, timeout::Nothing, skip::Bool, failfast::Nothing, file::String, line::Int32, project_root::String, code::Expr, testsetups::Vector{TestSetup}, workerid::Base.RefValue{Int32}, testsets::Vector{Test.DefaultTestSet}, eval_number::Base.RefValue{Int32}, stats::Vector{ReTestItems.PerfStats}, scheduled_for_evaluation::ReTestItems.ScheduledForEvaluation)
```