### PR TITLE
Update CI to use `julia-actions/cache` and `1.12` + fixes for 1.12

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
         version:
           - '1.8'
           - '1.10'
-          - '1.11'
+          - '~1.12.0-rc1'
         os:
           - ubuntu-latest
           - macOS-latest
@@ -35,9 +35,7 @@ jobs:
           - os: windows-latest
             arch: x64
           - os: windows-latest
-            version: 1.8
-          - os: windows-latest
-            version: 1.11
+            version: '1.8'
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,16 +44,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v4
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReTestItems"
 uuid = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
-version = "1.33.1"
+version = "1.33.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -994,12 +994,8 @@ function should_skip(ti::TestItem)
     softscope_all!(skip_body)
     # Run in a new module to not pollute `Main`.
     # Need to store the result of the `skip` expression so we can check it.
-    mod_name = gensym(Symbol(:skip_, ti.name))
-    skip_var = gensym(:skip)
-    skip_mod_expr = :(module $mod_name; $skip_var = $skip_body; end)
-    skip_mod = Core.eval(Main, skip_mod_expr)
-    # Check what the expression evaluated to.
-    skip = getfield(skip_mod, skip_var)
+    mod = Module(Symbol(:skip_, ti.name))
+    skip = Core.eval(mod, skip_body)
     !isa(skip, Bool) && _throw_not_bool(ti, skip)
     return skip::Bool
 end

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -776,6 +776,7 @@ end
 
 # for each directory, kick off a recursive test-finding task
 # Returns (testitems::TestItems, setups::Dict{Symbol,TestSetup})
+# Assumes `isdir(project_root)`, which is guaranteed by `_runtests`.
 function include_testfiles!(project_name, projectfile, paths, ti_filter::TestItemFilter, verbose_results::Bool, report::Bool)
     project_root = dirname(projectfile)
     subproject_root = nothing  # don't recurse into directories with their own Project.toml.
@@ -795,45 +796,43 @@ function include_testfiles!(project_name, projectfile, paths, ti_filter::TestIte
         return setups
     end
     hidden_re = r"\.\w"
-    if isdir(project_root) # https://github.com/JuliaLang/julia/issues/59092
-        @sync for (root, d, files) in Base.walkdir(project_root)
-            if subproject_root !== nothing && startswith(root, subproject_root)
-                @debugv 1 "Skipping files in `$root` in subproject `$subproject_root`"
-                continue
-            elseif _is_subproject(root, projectfile)
-                subproject_root = root
+    @sync for (root, d, files) in Base.walkdir(project_root)
+        if subproject_root !== nothing && startswith(root, subproject_root)
+            @debugv 1 "Skipping files in `$root` in subproject `$subproject_root`"
+            continue
+        elseif _is_subproject(root, projectfile)
+            subproject_root = root
+            continue
+        end
+        rpath = nestedrelpath(root, project_root)
+        startswith(rpath, hidden_re) && continue # skip hidden directories
+        dir_node = DirNode(rpath; report, verbose=verbose_results)
+        dir_nodes[rpath] = dir_node
+        push!(get(dir_nodes, dirname(rpath), root_node), dir_node)
+        for file in files
+            startswith(file, hidden_re) && continue # skip hidden files
+            filepath = joinpath(root, file)
+            # We filter here, rather than the testitem level, to make sure we don't
+            # `include` a file that isn't supposed to be a test-file at all, e.g. its
+            # not on a path the user requested but it happens to have a test-file suffix.
+            # We always include testsetup-files so users don't need to request them,
+            # even if they're not in a requested path, e.g. they are a level up in the
+            # directory tree. The testsetup-file suffix is hopefully specific enough
+            # to ReTestItems that this doesn't lead to `include`ing unexpected files.
+            if !(is_testsetup_file(filepath) || (is_test_file(filepath) && is_requested(filepath, paths)))
                 continue
             end
-            rpath = nestedrelpath(root, project_root)
-            startswith(rpath, hidden_re) && continue # skip hidden directories
-            dir_node = DirNode(rpath; report, verbose=verbose_results)
-            dir_nodes[rpath] = dir_node
-            push!(get(dir_nodes, dirname(rpath), root_node), dir_node)
-            for file in files
-                startswith(file, hidden_re) && continue # skip hidden files
-                filepath = joinpath(root, file)
-                # We filter here, rather than the testitem level, to make sure we don't
-                # `include` a file that isn't supposed to be a test-file at all, e.g. its
-                # not on a path the user requested but it happens to have a test-file suffix.
-                # We always include testsetup-files so users don't need to request them,
-                # even if they're not in a requested path, e.g. they are a level up in the
-                # directory tree. The testsetup-file suffix is hopefully specific enough
-                # to ReTestItems that this doesn't lead to `include`ing unexpected files.
-                if !(is_testsetup_file(filepath) || (is_test_file(filepath) && is_requested(filepath, paths)))
-                    continue
-                end
-                fpath = nestedrelpath(filepath, project_root)
-                file_node = FileNode(fpath, ti_filter; report, verbose=verbose_results)
-                testitem_names = Set{String}() # to enforce that names in the same file are unique
-                push!(dir_node, file_node)
-                @debugv 1 "Including test items from file `$filepath`"
-                @spawn begin
-                    task_local_storage(:__RE_TEST_RUNNING__, true) do
-                        task_local_storage(:__RE_TEST_ITEMS__, ($file_node, $testitem_names)) do
-                            task_local_storage(:__RE_TEST_PROJECT__, $(project_root)) do
-                                task_local_storage(:__RE_TEST_SETUPS__, $setup_channel) do
-                                    Base.include($ti_filter, Main, $filepath)
-                                end
+            fpath = nestedrelpath(filepath, project_root)
+            file_node = FileNode(fpath, ti_filter; report, verbose=verbose_results)
+            testitem_names = Set{String}() # to enforce that names in the same file are unique
+            push!(dir_node, file_node)
+            @debugv 1 "Including test items from file `$filepath`"
+            @spawn begin
+                task_local_storage(:__RE_TEST_RUNNING__, true) do
+                    task_local_storage(:__RE_TEST_ITEMS__, ($file_node, $testitem_names)) do
+                        task_local_storage(:__RE_TEST_PROJECT__, $(project_root)) do
+                            task_local_storage(:__RE_TEST_SETUPS__, $setup_channel) do
+                                Base.include($ti_filter, Main, $filepath)
                             end
                         end
                     end

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -993,7 +993,6 @@ function should_skip(ti::TestItem)
     skip_body = deepcopy(ti.skip::Expr)
     softscope_all!(skip_body)
     # Run in a new module to not pollute `Main`.
-    # Need to store the result of the `skip` expression so we can check it.
     mod = Module(Symbol(:skip_, ti.name))
     skip = Core.eval(mod, skip_body)
     !isa(skip, Bool) && _throw_not_bool(ti, skip)

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -795,43 +795,45 @@ function include_testfiles!(project_name, projectfile, paths, ti_filter::TestIte
         return setups
     end
     hidden_re = r"\.\w"
-    @sync for (root, d, files) in Base.walkdir(project_root)
-        if subproject_root !== nothing && startswith(root, subproject_root)
-            @debugv 1 "Skipping files in `$root` in subproject `$subproject_root`"
-            continue
-        elseif _is_subproject(root, projectfile)
-            subproject_root = root
-            continue
-        end
-        rpath = nestedrelpath(root, project_root)
-        startswith(rpath, hidden_re) && continue # skip hidden directories
-        dir_node = DirNode(rpath; report, verbose=verbose_results)
-        dir_nodes[rpath] = dir_node
-        push!(get(dir_nodes, dirname(rpath), root_node), dir_node)
-        for file in files
-            startswith(file, hidden_re) && continue # skip hidden files
-            filepath = joinpath(root, file)
-            # We filter here, rather than the testitem level, to make sure we don't
-            # `include` a file that isn't supposed to be a test-file at all, e.g. its
-            # not on a path the user requested but it happens to have a test-file suffix.
-            # We always include testsetup-files so users don't need to request them,
-            # even if they're not in a requested path, e.g. they are a level up in the
-            # directory tree. The testsetup-file suffix is hopefully specific enough
-            # to ReTestItems that this doesn't lead to `include`ing unexpected files.
-            if !(is_testsetup_file(filepath) || (is_test_file(filepath) && is_requested(filepath, paths)))
+    if isdir(project_root) # https://github.com/JuliaLang/julia/issues/59092
+        @sync for (root, d, files) in Base.walkdir(project_root)
+            if subproject_root !== nothing && startswith(root, subproject_root)
+                @debugv 1 "Skipping files in `$root` in subproject `$subproject_root`"
+                continue
+            elseif _is_subproject(root, projectfile)
+                subproject_root = root
                 continue
             end
-            fpath = nestedrelpath(filepath, project_root)
-            file_node = FileNode(fpath, ti_filter; report, verbose=verbose_results)
-            testitem_names = Set{String}() # to enforce that names in the same file are unique
-            push!(dir_node, file_node)
-            @debugv 1 "Including test items from file `$filepath`"
-            @spawn begin
-                task_local_storage(:__RE_TEST_RUNNING__, true) do
-                    task_local_storage(:__RE_TEST_ITEMS__, ($file_node, $testitem_names)) do
-                        task_local_storage(:__RE_TEST_PROJECT__, $(project_root)) do
-                            task_local_storage(:__RE_TEST_SETUPS__, $setup_channel) do
-                                Base.include($ti_filter, Main, $filepath)
+            rpath = nestedrelpath(root, project_root)
+            startswith(rpath, hidden_re) && continue # skip hidden directories
+            dir_node = DirNode(rpath; report, verbose=verbose_results)
+            dir_nodes[rpath] = dir_node
+            push!(get(dir_nodes, dirname(rpath), root_node), dir_node)
+            for file in files
+                startswith(file, hidden_re) && continue # skip hidden files
+                filepath = joinpath(root, file)
+                # We filter here, rather than the testitem level, to make sure we don't
+                # `include` a file that isn't supposed to be a test-file at all, e.g. its
+                # not on a path the user requested but it happens to have a test-file suffix.
+                # We always include testsetup-files so users don't need to request them,
+                # even if they're not in a requested path, e.g. they are a level up in the
+                # directory tree. The testsetup-file suffix is hopefully specific enough
+                # to ReTestItems that this doesn't lead to `include`ing unexpected files.
+                if !(is_testsetup_file(filepath) || (is_test_file(filepath) && is_requested(filepath, paths)))
+                    continue
+                end
+                fpath = nestedrelpath(filepath, project_root)
+                file_node = FileNode(fpath, ti_filter; report, verbose=verbose_results)
+                testitem_names = Set{String}() # to enforce that names in the same file are unique
+                push!(dir_node, file_node)
+                @debugv 1 "Including test items from file `$filepath`"
+                @spawn begin
+                    task_local_storage(:__RE_TEST_RUNNING__, true) do
+                        task_local_storage(:__RE_TEST_ITEMS__, ($file_node, $testitem_names)) do
+                            task_local_storage(:__RE_TEST_PROJECT__, $(project_root)) do
+                                task_local_storage(:__RE_TEST_SETUPS__, $setup_channel) do
+                                    Base.include($ti_filter, Main, $filepath)
+                                end
                             end
                         end
                     end

--- a/test/integrationtests.jl
+++ b/test/integrationtests.jl
@@ -947,7 +947,7 @@ end
         @testset "non-zero timeout_profile_wait means we collect a CPU profile" begin
             capture_timeout_profile(5) do logs
                 @test occursin("Information request received. A stacktrace will print followed by a $(default_peektime) second profile", logs)
-                @test count(r"pthread_cond_wait|__psych_cvwait", logs) > 0 # the stacktrace was printed (will fail on Windows)
+                @test count(r"pthread_cond_wait|__psynch_cvwait", logs) > 0 # the stacktrace was printed (will fail on Windows)
                 @test occursin("Profile collected.", logs)
             end
         end
@@ -956,7 +956,7 @@ end
         @testset "`set_peek_duration` is respected in `worker_init_expr`" begin
             capture_timeout_profile(5, worker_init_expr=:(using Profile; Profile.set_peek_duration($default_peektime + 1.0))) do logs
                 @test occursin("Information request received. A stacktrace will print followed by a $(default_peektime + 1.0) second profile", logs)
-                @test count(r"pthread_cond_wait|__psych_cvwait", logs) > 0 # the stacktrace was printed (will fail on Windows)
+                @test count(r"pthread_cond_wait|__psynch_cvwait", logs) > 0 # the stacktrace was printed (will fail on Windows)
                 @test occursin("Profile collected.", logs)
             end
         end
@@ -967,7 +967,7 @@ end
             withenv("RETESTITEMS_TIMEOUT_PROFILE_WAIT" => "5") do
                 capture_timeout_profile(nothing) do logs
                     @test occursin("Information request received", logs)
-                    @test count(r"pthread_cond_wait|__psych_cvwait", logs) > 0 # the stacktrace was printed (will fail on Windows)
+                    @test count(r"pthread_cond_wait|__psynch_cvwait", logs) > 0 # the stacktrace was printed (will fail on Windows)
                     @test occursin("Profile collected.", logs)
                 end
             end
@@ -977,7 +977,7 @@ end
         @testset "CPU profile with $(repr(log_capture))" for log_capture in (:eager, :batched)
             capture_timeout_profile(5, nworker_threads=VERSION >= v"1.9" ? "3,2" : "3", logs=log_capture) do logs
                 @test occursin("Information request received", logs)
-                @test count(r"pthread_cond_wait|__psych_cvwait", logs) > 0 # the stacktrace was printed (will fail on Windows)
+                @test count(r"pthread_cond_wait|__psynch_cvwait", logs) > 0 # the stacktrace was printed (will fail on Windows)
                 @test occursin("Profile collected.", logs)
             end
         end

--- a/test/integrationtests.jl
+++ b/test/integrationtests.jl
@@ -173,7 +173,12 @@ end
     @test_throws ReTestItems.NoTestException runtests(ti -> :b_tag in ti.tags, pkg; name="b", tags=[:nope])
 
     # can only filter on `ti.name` and `ti.tags` (at least for now)
-    @test_throws "no field file" runtests(ti -> contains(ti.file, "bar_"), pkg)
+    expected = if VERSION < v"1.12.0-DEV"
+        "no field file"
+    else
+        "no field `file`"
+    end
+    @test_throws expected runtests(ti -> contains(ti.file, "bar_"), pkg)
 end
 
 @testset "`@testitem` scoping rules" begin

--- a/test/internals.jl
+++ b/test/internals.jl
@@ -300,7 +300,7 @@ end
 end
 
 @testset "should_skip" begin
-    should_skip = ReTestItems.should_skip
+    using ReTestItems: should_skip
 
     ti = @testitem("x", skip=true, _run=false, begin end)
     @test should_skip(ti)

--- a/test/internals.jl
+++ b/test/internals.jl
@@ -92,17 +92,18 @@ end
     shouldrun = TestItemFilter(Returns(true), nothing, nothing)
     verbose_results = false
     report = false
+    project = touch(joinpath(mktempdir(), "Project.toml"))
 
     # Requesting only non-existent files/dirs should result in no files being included
-    ti, setups = include_testfiles!("proj", "/this/file/", ("/this/file/is/not/a/t-e-s-tfile.jl",), shouldrun, verbose_results, report)
+    ti, setups = include_testfiles!("proj", project, ("/this/file/is/not/a/t-e-s-tfile.jl",), shouldrun, verbose_results, report)
     @test isempty(ti.testitems)
     @test isempty(setups)
 
-    ti, setups = include_testfiles!("proj", "/this/file/", ("/this/file/does/not/exist/imaginary_tests.jl",), shouldrun, verbose_results, report)
+    ti, setups = include_testfiles!("proj", project, ("/this/file/does/not/exist/imaginary_tests.jl",), shouldrun, verbose_results, report)
     @test isempty(ti.testitems)
     @test isempty(setups)
 
-    ti, setups = include_testfiles!("proj", "/this/dir/", ("/this/dir/does/not/exist/", "/this/dir/also/not/exist/"), shouldrun, verbose_results, report)
+    ti, setups = include_testfiles!("proj", project, ("/this/dir/does/not/exist/", "/this/dir/also/not/exist/"), shouldrun, verbose_results, report)
     @test isempty(ti.testitems)
     @test isempty(setups)
 

--- a/test/workers.jl
+++ b/test/workers.jl
@@ -107,15 +107,20 @@ using Test
                 return read(path, String)
             end
 
-            @test occursin(r"Thread 1 Task 0x\w+ Total snapshots: \d+. Utilization: \d+%", logs)
-            @test occursin(r"Thread 2 Task 0x\w+ Total snapshots: \d+. Utilization: \d+%", logs)
-            @test occursin(r"Thread 3 Task 0x\w+ Total snapshots: \d+. Utilization: \d+%", logs)
+            # In Julia v1.12+ looks it prints the threadpool, like:
+            # Thread 1 (interactive) Task 0x00007f03563fc010 Total snapshots: 597. Utilization: 0%
+            # Thread 5 (default) Task 0x00007f03563fe2c0 Total snapshots: 597. Utilization: 20%
+            re_thread(i::Int) = Regex("Thread $i( \\((default|interactive)\\))? Task 0x")
+            @test occursin(re_thread(1), logs)
+            @test occursin(re_thread(2), logs)
+            @test occursin(re_thread(3), logs)
+
             if VERSION >= v"1.9"
-                @test occursin(r"Thread 4 Task 0x\w+ Total snapshots: \d+. Utilization: \d+%", logs)
-                @test occursin(r"Thread 5 Task 0x\w+ Total snapshots: \d+. Utilization: \d+%", logs)
-                @test !occursin(r"Thread 6 Task 0x\w+ Total snapshots: \d+. Utilization: \d+%", logs)
+                @test occursin(re_thread(4), logs)
+                @test occursin(re_thread(5), logs)
+                @test !occursin(re_thread(6), logs)
             else
-                @test !occursin(r"Thread 4 Task 0x\w+ Total snapshots: \d+. Utilization: \d+%", logs)
+                @test !occursin(re_thread(4), logs)
             end
         end
     end


### PR DESCRIPTION
- Update CI to use `julia-actions/cache` and also test against (unreleased) Julia version `1.12` (close https://github.com/JuliaTesting/ReTestItems.jl/issues/207)
  - tests and not yet required to pass on v1.12 (given it's not released yet)
- Fix one genuine v1.12 issue in the code: `skip` keyword implementation had world age issues
```julia
ERROR: UndefVarError: `##skip#279` not defined in `Main.var"##skip_JET error analysis RAI_CompilationsCache package#278"`
The binding may be too new: running in world age 38585, while current world is 38587.
Stacktrace:
  [1] should_skip(ti::TestItem)
    @ ReTestItems ~/.julia/packages/ReTestItems/SUewn/src/ReTestItems.jl:998
  [2] runtestitem(ti::TestItem, ctx::ReTestItems.TestContext; test_end_expr::Expr, logs::Symbol, verbose_results::Bool, finish_test::Bool, catch_test_error::Bool, failfast::Bool)
    @ ReTestItems ~/.julia/packages/ReTestItems/SUewn/src/ReTestItems.jl:1038
```
- document `walkdir` assumption (following https://github.com/JuliaLang/julia/issues/59092) and update tests accordingly
- update test regex (following https://github.com/JuliaLang/julia/pull/54994)

This leaves one test still failing on v1.12 (the test `runtests() TestProjectFile.jl`)
