### PR TITLE
Replace `Base.walkdir` with variation that skips hidden directories

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReTestItems"
 uuid = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
-version = "1.35.0"
+version = "1.35.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/ReTestItems.jl
+++ b/src/ReTestItems.jl
@@ -793,7 +793,7 @@ end
 # Like `Base.walkdir` but does not descend into hidden directories (those starting with '.')
 function _walkdir(root)
     return Channel{Tuple{String, Vector{String}, Vector{String}}}() do ch
-        for (dir, dirs, files) in Base.walkdir(root)
+        for (dir, dirs, files) in Base.walkdir(root; topdown=true)
             # Filter out hidden directories to prevent descending into them.
             # Modifying `dirs` in-place works because walkdir uses it to determine
             # which subdirectories to visit next (when topdown=true, the default).


### PR DESCRIPTION
@charnik reported seeing long "scanning for test items" times, e.g.:
```julia
julia> @time runtests("test/Server/get-julia-replay-traces-tests.jl", name="get_julia_replay_traces: error case")
┌ Info: 2026-01-15T19:13:42.622
└ Scanning for test items in project `RAICode` at paths: test/Server/get-julia-replay-traces-tests.jl
┌ Info: 2026-01-15T19:13:47.886
└ Finished scanning for test items in 5.26 seconds. <-----
```
This comes from having large "hidden directories", including in this case `.julia`, at the root of the repo

Because ReTestItems.jl always searches down from the root of the repo looking for test files we were descending into hidden directories. This PR fixes that so we now skip hidden directories. 

On that use-case, this PR reduces the scan time down from `5.26` to `0.21` seconds.
