### PR TITLE
Add `init_expr` keyword argument to `runtests`

### DIFF
--- a/test/integrationtests.jl
+++ b/test/integrationtests.jl
@@ -247,13 +247,14 @@ end
 
 @testset "init_expr" verbose=true begin
     init_expr_test_file = joinpath(TEST_FILES_DIR, "_init_expr_test.jl")
+    # Use @eval to assign to Main, which works in Julia 1.8+
     init_expr = quote
-        Main.INIT_EXPR_RAN = true
+        @eval Main INIT_EXPR_RAN = true
     end
 
     @testset "init_expr runs when nworkers=0" begin
         # Clean up any previous state
-        isdefined(Main, :INIT_EXPR_RAN) && (Main.INIT_EXPR_RAN = false)
+        @eval Main INIT_EXPR_RAN = false
         results = encased_testset() do
             runtests(init_expr_test_file; nworkers=0, init_expr)
         end

--- a/test/testfiles/_init_expr_test.jl
+++ b/test/testfiles/_init_expr_test.jl
@@ -1,0 +1,6 @@
+@testitem "init_expr sets global" begin
+    # This test checks that `init_expr` was run before this testitem.
+    # The init_expr should set `Main.INIT_EXPR_RAN` to `true`.
+    @test isdefined(Main, :INIT_EXPR_RAN)
+    @test Main.INIT_EXPR_RAN == true
+end


### PR DESCRIPTION
## Summary

- Add new `init_expr` keyword argument that runs initialization code before any tests
- Unlike `worker_init_expr`, `init_expr` also works when `nworkers=0`
- When `nworkers>0`, runs on each worker process (same as `worker_init_expr`)
- When `nworkers=0`, runs in the main process before test execution
- Error if both `init_expr` and `worker_init_expr` are specified

## Test plan

- [x] Added integration tests for `init_expr` with `nworkers=0`
- [x] Added integration tests for `init_expr` with `nworkers>0`
- [x] Added test that specifying both `init_expr` and `worker_init_expr` throws `ArgumentError`

🤖 Generated with [Claude Code](https://claude.ai/code)