### PR TITLE
WIP: Report aggregated time for directories and files

### DIFF
--- a/src/testcontext.jl
+++ b/src/testcontext.jl
@@ -116,12 +116,23 @@ function record_results!(ti::TestItems)
     return ti
 end
 
+function test_record!(ts_parent, ts_child)
+    record_test_time!(ts_parent, ts_child)
+    Test.record(ts_parent, ts_child)
+end
+
+function record_test_time!(ts_parent, ts_child)
+    ts_parent.time_end = something(ts_parent.time_end, ts_parent.time_start)
+    child_duration = ts_child.time_end::Float64 - ts_child.time_start
+    ts_parent.time_end += child_duration
+end
+
 function record_results!(dir::DirNode, child_dir::DirNode)
     @debugv 1 "Recording dir $(repr(child_dir.path)) to dir $(repr(dir.path))"
     foreach(child_dir.children) do child
         record_results!(child_dir, child)
     end
-    Test.record(dir.testset, child_dir.testset)
+    test_record!(dir.testset, child_dir.testset)
     junit_record!(dir.junit, child_dir.junit)
 end
 
@@ -130,7 +141,7 @@ function record_results!(dir::DirNode, file::FileNode)
     foreach(file.testitems) do ti
         record_results!(file, ti)
     end
-    Test.record(dir.testset, file.testset)
+    test_record!(dir.testset, file.testset)
     junit_record!(dir.junit, file.junit)
 end
 
@@ -139,7 +150,7 @@ function record_results!(file::FileNode, ti::TestItem)
     # If `failfast`, this testitem might never have been run, so nothing to record.
     if ti.eval_number[] != 0
         # Always record last try as the final status, so a pass-on-retry is a pass.
-        Test.record(file.testset, last(ti.testsets))
+        test_record!(file.testset, last(ti.testsets))
         junit_record!(file.junit, ti)
         _cache_status!(ti)
     end


### PR DESCRIPTION
before
```julia
julia> using ReTestItems; runtests("test/packages/TestOnlyDeps.jl/")
  Activating project at `~/repos/ReTestItems.jl/test/packages/TestOnlyDeps.jl`
┌ Warning: The project dependencies or compat requirements have changed since the manifest was last resolved.
│ It is recommended to `Pkg.resolve()` or consider `Pkg.update()` if necessary.
└ @ Pkg.API ~/repos/rai-julia/usr/share/julia/stdlib/v1.10/Pkg/src/API.jl:1807
[ Info: Scanning for test items in project `TestOnlyDeps` at paths: test/packages/TestOnlyDeps.jl/
[ Info: Finished scanning for test items in 0.52 seconds.
[ Info: Scheduling 2 tests on pid 56765
20:54:50 | START (1/2) test item "use a test-only dep" at test/deps_tests.jl:1
20:54:50 | DONE  (1/2) test item "use a test-only dep" <0.1 secs (89.4% compile), 59.86 K allocs (4.582 MB)
20:54:50 | START (2/2) test item "deps as expected" at test/deps_tests.jl:6
20:54:50 | DONE  (2/2) test item "deps as expected" <0.1 secs (58.7% compile), 7.00 K allocs (526.320 KB)
[ Tests Completed: 2/2 test items were run.
Test Summary:             | Pass  Total  Time
TestOnlyDeps              |    2      2  0.4s
  test                    |    2      2
    test/deps_tests.jl    |    2      2
      use a test-only dep |    1      1  0.1s
      deps as expected    |    1      1  0.0s
```

after
```julia
julia> using ReTestItems; runtests("test/packages/TestOnlyDeps.jl/")
  Activating project at `~/repos/ReTestItems.jl/test/packages/TestOnlyDeps.jl`
[ Info: Scanning for test items in project `TestOnlyDeps` at paths: test/packages/TestOnlyDeps.jl/
[ Info: Finished scanning for test items in 0.54 seconds.
[ Info: Scheduling 2 tests on pid 53254
20:53:43 | START (1/2) test item "use a test-only dep" at test/deps_tests.jl:1
20:53:43 | DONE  (1/2) test item "use a test-only dep" <0.1 secs (89.8% compile), 59.86 K allocs (4.582 MB)
20:53:43 | START (2/2) test item "deps as expected" at test/deps_tests.jl:6
20:53:43 | DONE  (2/2) test item "deps as expected" <0.1 secs (55.8% compile), 7.00 K allocs (526.320 KB)
[ Tests Completed: 2/2 test items were run.
Test Summary:             | Pass  Total  Time
TestOnlyDeps              |    2      2  0.4s
  test                    |    2      2  0.1s    # <--
    test/deps_tests.jl    |    2      2  0.1s    # <--
      use a test-only dep |    1      1  0.1s
      deps as expected    |    1      1  0.0s
```