### PR TITLE
Avoid throwing when workers shutdown on Windows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
         version:
           - '1.8'
           - '1.10'
-          - '~1.12.0-rc1'
+          - '1.12'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ReTestItems"
 uuid = "817f1d60-ba6b-4fd5-9520-3cf149f6a823"
-version = "1.35.1"
+version = "1.35.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/workers.jl
+++ b/src/workers.jl
@@ -84,7 +84,14 @@ function terminate!(w::Worker, from::Symbol=:manual)
     end
     signal = Base.SIGTERM
     while true
-        kill(w.process, signal)
+        try
+            kill(w.process, signal)
+        catch e
+            # Windows: TerminateProcess on a process that is currently exiting
+            # fails with ERROR_ACCESS_DENIED before the process object is
+            # signaled; libuv surfaces that as EACCES instead of ESRCH.
+            (Sys.iswindows() && e isa Base.IOError && e.code == Base.UV_EACCES) || rethrow()
+        end
         signal = signal == Base.SIGTERM ? Base.SIGINT : Base.SIGKILL
         process_exited(w.process) && break
         sleep(0.1)

--- a/test/junit_xml.jl
+++ b/test/junit_xml.jl
@@ -50,6 +50,7 @@ function test_reference(reference, comparison)
     end
     a = remove_variables(read(reference, String))
     b = remove_variables(read(comparison, String))
+    b = VERSION >= v"1.12" ? replace(b, r" *Suggestion: check for spelling errors or missing imports. *\n" => "") : b
     if a == b
         @test true
         return nothing


### PR DESCRIPTION
When porting a private package to Julia 1.12, I consistently ran into issues when all the tests pass but the test run failed with an error pointing to worker termination: 
```julia
ERROR: LoadError: TaskFailedException
    nested task error: TaskFailedException
    Stacktrace:
      [1] #wait#582
        @ .\task.jl:363 [inlined]
      [2] wait
        @ .\task.jl:360 [inlined]
      [3] fetch
        @ .\task.jl:554 [inlined]
      [4] wait
        @ .\packages\ReTestItems\rFUty\src\workers.jl:145 [inlined]
      [5] close(w::ReTestItems.Workers.Worker)
        @ ReTestItems.Workers .\packages\ReTestItems\rFUty\src\workers.jl:140
      [6] manage_worker(worker::ReTestItems.Workers.Worker, proj_name::String, testitems::ReTestItems.TestItems, testitem::TestItem, cfg::ReTestItems._Config; worker_num::Int64)
        @ ReTestItems .\packages\ReTestItems\rFUty\src\ReTestItems.jl:753
        ...
        nested task error: IOError: kill: permission denied (EACCES)
        Stacktrace:
         [1] kill(p::Base.Process, signum::Int64)
           @ Base .\process.jl:627
         [2] terminate!(w::ReTestItems.Workers.Worker, from::Symbol)
           @ ReTestItems.Workers .\packages\ReTestItems\rFUty\src\workers.jl:87
         [3] process_responses(w::ReTestItems.Workers.Worker, ev::Base.Event)
           @ ReTestItems.Workers .\packages\ReTestItems\rFUty\src\workers.jl:272
         [4] (::ReTestItems.Workers.var"#18#19"{ReTestItems.Workers.Worker, Base.Event})()
           @ ReTestItems.Workers .\packages\ReTestItems\rFUty\src\workers.jl:206
        caused by: EOFError: read end of file
        Stacktrace:
         [1] read(this::Sockets.TCPSocket, ::Type{UInt8})
           @ Base .\stream.jl:1012
         [2] deserialize
           @ .\stdlib\v1.12\Serialization\src\Serialization.jl:851 [inlined]
         [3] deserialize(s::Sockets.TCPSocket)
           @ Serialization .\stdlib\v1.12\Serialization\src\Serialization.jl:838
         [4] process_responses(w::ReTestItems.Workers.Worker, ev::Base.Event)
           @ ReTestItems.Workers .\packages\ReTestItems\rFUty\src\workers.jl:254
         [5] (::ReTestItems.Workers.var"#18#19"{ReTestItems.Workers.Worker, Base.Event})()
           @ ReTestItems.Workers .\packages\ReTestItems\rFUty\src\workers.jl:206
...and 4 more exceptions.
Stacktrace:
  [1] sync_end(c::Channel{Any})
  ...
```
The issue seems to be that when a worker shuts down, the managing task gets an `EOFError` when listening for messages to `deserialize` from the worker, and then in a catch block it tries to `terminate!` the already-shut-down worker, but it seems that marking the worker as done is racy (i.e. its `process_running(p)` can still return `true` at this point), so we end up trying to kill an exited worker, which results in an access violation error on Windows.

With this patch, the issue no longer reproduces.
I also fixed a junit_xml.jl tests since some of the error messages changed on Julia 1.12, and I bumped the CI Julia version from  `'~1.12.0-rc1'` to `'1.12'`


